### PR TITLE
feat: add schedule screen with month/week/day views

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1430,7 +1429,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1472,7 +1470,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1578,7 +1575,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1813,7 +1809,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2500,7 +2495,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2562,7 +2556,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2572,7 +2565,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -2841,7 +2833,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -2963,7 +2954,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,14 +26,14 @@ function App() {
   const routesWithoutBottomTab = ["/splash", "/signin"];
   const shouldShowBottomTab = !routesWithoutBottomTab.includes(location.pathname);
 
-  // No vertical scrolling screens
-  const noScrollRoutes = ["/splash", "/signin"];
+  // No vertical scrolling screens (schedule manages its own internal scroll)
+  const noScrollRoutes = ["/splash", "/signin", "/schedule"];
   const shouldDisableScroll = noScrollRoutes.includes(location.pathname);
 
   return (
     <div style={{
       ...styles.appContainer,
-      paddingBottom: shouldShowBottomTab ? "80px" : "0",
+      paddingBottom: shouldShowBottomTab && !shouldDisableScroll ? "80px" : "0",
       overflow: shouldDisableScroll ? "hidden" : "auto",
       height: shouldDisableScroll ? "100vh" : "auto",
       minHeight: shouldDisableScroll ? "unset" : "100vh",

--- a/src/components/schedule/Appointmentblock.jsx
+++ b/src/components/schedule/Appointmentblock.jsx
@@ -1,0 +1,129 @@
+// ─── src/components/schedule/AppointmentBlock.jsx ────────────────────────────
+/**
+ * Absolutely-positioned block rendered inside a timeline column.
+ *
+ * Props:
+ *   appointment {object}   { id, patientName, type, startTime, endTime, status }
+ *   top         {number}   px offset from top of timeline
+ *   height      {number}   px height of the block
+ *   compact     {boolean}  true = week view (less space), false = day view
+ *   onClick     {function} (appointment) => void
+ */
+
+import { getTypeColors, formatTime12h, APPOINTMENT_STATUS } from "./Scheduleutils";
+
+export default function AppointmentBlock({ appointment, top, height, compact = false, onClick }) {
+  const colors = getTypeColors(appointment.type);
+  const isCancelled = appointment.status === "Cancelled";
+  const statusCfg = APPOINTMENT_STATUS[appointment.status] ?? APPOINTMENT_STATUS["Scheduled"];
+
+  const shortName = (() => {
+    const parts = appointment.patientName.trim().split(" ");
+    return parts.length >= 2
+      ? `${parts[0][0]}. ${parts[parts.length - 1]}`
+      : appointment.patientName;
+  })();
+
+  return (
+    <button
+      onClick={() => onClick?.(appointment)}
+      title={`${appointment.patientName} — ${appointment.type} @ ${formatTime12h(appointment.startTime)}`}
+      style={{
+        ...styles.block,
+        top,
+        height,
+        background: isCancelled ? "#F2F2F7" : colors.bg,
+        borderLeft: `3px solid ${isCancelled ? "#C7C7CC" : colors.border}`,
+        opacity: isCancelled ? 0.65 : 1,
+      }}
+    >
+      {/* Time — shown only in day view */}
+      {!compact && (
+        <span style={{ ...styles.time, color: isCancelled ? "#8E8E93" : colors.text }}>
+          {formatTime12h(appointment.startTime)}
+        </span>
+      )}
+
+      {/* Patient name */}
+      <span style={{
+        ...styles.name,
+        color: isCancelled ? "#8E8E93" : colors.text,
+        fontSize: compact ? 9 : 12,
+      }}>
+        {compact ? shortName : appointment.patientName}
+      </span>
+
+      {/* Appointment type — only if tall enough */}
+      {height > 36 && (
+        <span style={{
+          ...styles.type,
+          color: isCancelled ? "#8E8E93" : colors.text,
+          fontSize: compact ? 8 : 10,
+        }}>
+          {appointment.type}
+        </span>
+      )}
+
+      {/* Status — day view only, tall enough */}
+      {!compact && height > 52 && (
+        <span style={{ ...styles.status, color: statusCfg.color }}>
+          {statusCfg.icon} {appointment.status}
+        </span>
+      )}
+
+      {/* Status dot — compact (week) view */}
+      {compact && height > 44 && (
+        <span style={{ fontSize: 8, color: statusCfg.color, lineHeight: 1 }}>
+          {statusCfg.icon}
+        </span>
+      )}
+    </button>
+  );
+}
+
+const styles = {
+  block: {
+    position: "absolute",
+    left: 2,
+    right: 2,
+    border: "none",
+    borderRadius: 6,
+    padding: "4px 6px",
+    cursor: "pointer",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "flex-start",
+    overflow: "hidden",
+    textAlign: "left",
+    boxShadow: "0 1px 3px rgba(0,0,0,0.06)",
+    fontFamily: "-apple-system, 'SF Pro Text', sans-serif",
+    gap: 1,
+  },
+  time: {
+    fontSize: 10,
+    fontWeight: 500,
+    lineHeight: 1.3,
+  },
+  name: {
+    fontWeight: 700,
+    lineHeight: 1.3,
+    whiteSpace: "nowrap",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    width: "100%",
+  },
+  type: {
+    opacity: 0.8,
+    lineHeight: 1.2,
+    whiteSpace: "nowrap",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    width: "100%",
+  },
+  status: {
+    fontSize: 10,
+    fontWeight: 500,
+    marginTop: 2,
+    lineHeight: 1,
+  },
+};

--- a/src/components/schedule/Appointmentpill.jsx
+++ b/src/components/schedule/Appointmentpill.jsx
@@ -1,0 +1,55 @@
+// ─── src/components/schedule/AppointmentPill.jsx ─────────────────────────────
+/**
+ * Small colored label shown inside month grid cells.
+ *
+ * Props:
+ *   appointment {object}   { id, patientName, type, status }
+ *   onClick     {function} (appointment) => void
+ */
+
+import { getTypeColors } from "./Scheduleutils";
+
+export default function AppointmentPill({ appointment, onClick }) {
+  const colors = getTypeColors(appointment.type);
+  const isCancelled = appointment.status === "Cancelled";
+
+  const nameParts = appointment.patientName.trim().split(" ");
+  const shortName =
+    nameParts.length >= 2
+      ? `${nameParts[0][0]}. ${nameParts[nameParts.length - 1]}`
+      : appointment.patientName;
+
+  return (
+    <button
+      onClick={() => onClick?.(appointment)}
+      title={`${appointment.patientName} — ${appointment.type}`}
+      style={{
+        ...styles.pill,
+        background: isCancelled ? "#F2F2F7" : colors.bg,
+        color: isCancelled ? "#8E8E93" : colors.text,
+        textDecoration: isCancelled ? "line-through" : "none",
+      }}
+    >
+      {shortName}
+    </button>
+  );
+}
+
+const styles = {
+  pill: {
+    display: "block",
+    width: "100%",
+    fontSize: 8.5,
+    fontWeight: 600,
+    borderRadius: 3,
+    padding: "1.5px 4px",
+    border: "none",
+    cursor: "pointer",
+    textAlign: "left",
+    overflow: "hidden",
+    whiteSpace: "nowrap",
+    textOverflow: "ellipsis",
+    lineHeight: 1.4,
+    fontFamily: "-apple-system, 'SF Pro Text', sans-serif",
+  },
+};

--- a/src/components/schedule/Calendarheader.jsx
+++ b/src/components/schedule/Calendarheader.jsx
@@ -1,0 +1,61 @@
+// ─── src/components/schedule/CalendarHeader.jsx ──────────────────────────────
+/**
+ * Props:
+ *   title        {string}   e.g. "April 2026" or "Wednesday - April 15, 2026"
+ *   onPrev       {function} called when left arrow tapped
+ *   onNext       {function} called when right arrow tapped
+ *   onTitlePress {function} called when title tapped (e.g. open date picker)
+ */
+
+export default function CalendarHeader({ title, onPrev, onNext, onTitlePress }) {
+  return (
+    <div style={styles.wrapper}>
+      <button onClick={onPrev} style={styles.arrow} aria-label="Previous">‹</button>
+
+      <button onClick={onTitlePress} style={styles.title} aria-label="Select date">
+        {title}
+        <span style={styles.caret}>▼</span>
+      </button>
+
+      <button onClick={onNext} style={styles.arrow} aria-label="Next">›</button>
+    </div>
+  );
+}
+
+const styles = {
+  wrapper: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    padding: "10px 16px 6px",
+    flexShrink: 0,
+  },
+  arrow: {
+    background: "none",
+    border: "none",
+    fontSize: 26,
+    color: "#007AFF",
+    cursor: "pointer",
+    padding: "0 8px",
+    lineHeight: 1,
+    borderRadius: 6,
+  },
+  title: {
+    background: "none",
+    border: "none",
+    fontSize: 18,
+    fontWeight: 700,
+    color: "#1C1C1E",
+    cursor: "pointer",
+    display: "flex",
+    alignItems: "center",
+    gap: 6,
+    fontFamily: "-apple-system, 'SF Pro Display', sans-serif",
+    padding: 0,
+  },
+  caret: {
+    fontSize: 10,
+    color: "#8E8E93",
+    marginTop: 2,
+  },
+};

--- a/src/components/schedule/Daytimeline.jsx
+++ b/src/components/schedule/Daytimeline.jsx
@@ -1,0 +1,68 @@
+// ─── src/components/schedule/DayTimeline.jsx ─────────────────────────────────
+/**
+ * Single-day scrollable timeline.
+ *
+ * Props:
+ *   dateStr            {string}   "YYYY-MM-DD"
+ *   appointments       {array}    appointments for this day
+ *   onAppointmentPress {function} (appointment) => void
+ */
+
+import AppointmentBlock from "./Appointmentblock";
+import TimeColumn from "./Timecolumn";
+import {
+  TIMELINE_HOURS,
+  HOUR_HEIGHT,
+  START_HOUR,
+  getTimelinePosition,
+} from "./Scheduleutils";
+
+export default function DayTimeline({ appointments = [], onAppointmentPress }) {
+  const visibleAppts = appointments.filter(
+    (a) => parseInt(a.startTime.split(":")[0]) >= START_HOUR
+  );
+
+  return (
+    <div style={styles.scrollArea}>
+      <div style={styles.body}>
+        <TimeColumn hours={TIMELINE_HOURS} hourHeight={HOUR_HEIGHT} />
+
+        <div style={styles.eventsColumn}>
+          {TIMELINE_HOURS.map((h) => (
+            <div key={h} style={{ height: HOUR_HEIGHT, borderBottom: "1px solid #F2F2F7" }} />
+          ))}
+
+          {visibleAppts.map((appt) => {
+            const { top, height } = getTimelinePosition(appt.startTime, appt.endTime);
+            return (
+              <AppointmentBlock
+                key={appt.id}
+                appointment={appt}
+                top={top}
+                height={height}
+                compact={false}
+                onClick={onAppointmentPress}
+              />
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const styles = {
+  scrollArea: {
+    flex: 1,
+    overflowY: "auto",
+  },
+  body: {
+    display: "flex",
+    position: "relative",
+  },
+  eventsColumn: {
+    flex: 1,
+    position: "relative",
+    borderLeft: "1px solid #E5E5EA",
+  },
+};

--- a/src/components/schedule/Monthgrid.jsx
+++ b/src/components/schedule/Monthgrid.jsx
@@ -1,0 +1,160 @@
+// ─── src/components/schedule/MonthGrid.jsx ───────────────────────────────────
+/**
+ * Full monthly calendar grid with appointment pills.
+ *
+ * Props:
+ *   year               {number}   e.g. 2026
+ *   month              {number}   0-indexed
+ *   selectedDate       {string}   "YYYY-MM-DD"
+ *   todayStr           {string}   "YYYY-MM-DD"
+ *   appointmentsByDate {object}   { "YYYY-MM-DD": [appointment, ...] }
+ *   onSelectDate       {function} (dateStr) => void
+ *   onAppointmentPress {function} (appointment) => void
+ */
+
+import AppointmentPill from "./Appointmentpill";
+import {
+  DAYS_SHORT,
+  getDaysInMonth,
+  getFirstDayOfMonth,
+  toDateString,
+} from "./Scheduleutils";
+
+const MAX_PILLS = 3;
+
+export default function MonthGrid({
+  year, month, selectedDate, todayStr,
+  appointmentsByDate, onSelectDate, onAppointmentPress,
+}) {
+  const daysInMonth = getDaysInMonth(year, month);
+  const firstDay = getFirstDayOfMonth(year, month);
+  const prevMonDays = getDaysInMonth(year, month === 0 ? 11 : month - 1);
+
+  // Build 42-cell grid (6 rows × 7 cols)
+  const cells = [];
+  for (let i = 0; i < firstDay; i++) {
+    cells.push({ day: prevMonDays - firstDay + 1 + i, isCurrent: false, dateStr: null });
+  }
+  for (let d = 1; d <= daysInMonth; d++) {
+    cells.push({ day: d, isCurrent: true, dateStr: toDateString(year, month, d) });
+  }
+  for (let d = 1; d <= 42 - cells.length; d++) {
+    cells.push({ day: d, isCurrent: false, dateStr: null });
+  }
+
+  return (
+    <div style={styles.wrapper}>
+      {/* Day-of-week header row */}
+      <div style={styles.headerRow}>
+        {DAYS_SHORT.map((d, i) => (
+          <div key={i} style={styles.headerCell}>{d}</div>
+        ))}
+      </div>
+
+      {/* Calendar grid */}
+      <div style={styles.grid}>
+        {cells.map((cell, i) => {
+          const isToday = cell.dateStr === todayStr;
+          const isSelected = cell.dateStr === selectedDate;
+          const appts = cell.dateStr ? (appointmentsByDate[cell.dateStr] ?? []) : [];
+          const shown = appts.slice(0, MAX_PILLS);
+          const overflow = appts.length - MAX_PILLS;
+
+          return (
+            <div
+              key={i}
+              onClick={() => cell.isCurrent && cell.dateStr && onSelectDate(cell.dateStr)}
+              style={{
+                ...styles.cell,
+                cursor: cell.isCurrent ? "pointer" : "default",
+                background: isSelected && cell.isCurrent ? "#EEF4FF" : "transparent",
+              }}
+            >
+              <div style={{
+                ...styles.dayNum,
+                background: isToday ? "#007AFF" : "transparent",
+                color: isToday ? "#fff" : cell.isCurrent ? "#1C1C1E" : "#C7C7CC",
+                fontWeight: isToday ? 700 : 400,
+              }}>
+                {cell.day}
+              </div>
+
+              <div style={styles.pills}>
+                {shown.map((appt) => (
+                  <AppointmentPill
+                    key={appt.id}
+                    appointment={appt}
+                    onClick={onAppointmentPress}
+                  />
+                ))}
+                {overflow > 0 && (
+                  <span style={styles.overflow}>+{overflow} more</span>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+const styles = {
+  wrapper: {
+    display: "flex",
+    flexDirection: "column",
+    flex: 1,
+    padding: "0 6px",
+    overflow: "hidden",
+  },
+  headerRow: {
+    display: "grid",
+    gridTemplateColumns: "repeat(7, 1fr)",
+    marginBottom: 2,
+    flexShrink: 0,
+  },
+  headerCell: {
+    textAlign: "center",
+    fontSize: 11,
+    fontWeight: 600,
+    color: "#8E8E93",
+    padding: "4px 0",
+    fontFamily: "-apple-system, 'SF Pro Text', sans-serif",
+  },
+  grid: {
+    display: "grid",
+    gridTemplateColumns: "repeat(7, 1fr)",
+    flex: 1,
+    overflow: "hidden",
+  },
+  cell: {
+    minHeight: 56,
+    padding: "2px 2px 4px",
+    display: "flex",
+    flexDirection: "column",
+    gap: 1,
+    borderRadius: 6,
+  },
+  dayNum: {
+    width: 22,
+    height: 22,
+    borderRadius: "50%",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    fontSize: 12,
+    margin: "0 auto 2px",
+    fontFamily: "-apple-system, 'SF Pro Text', sans-serif",
+  },
+  pills: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 1,
+  },
+  overflow: {
+    fontSize: 7.5,
+    color: "#8E8E93",
+    paddingLeft: 3,
+    fontFamily: "-apple-system, 'SF Pro Text', sans-serif",
+  },
+};

--- a/src/components/schedule/Scheduleutils.js
+++ b/src/components/schedule/Scheduleutils.js
@@ -1,0 +1,87 @@
+// ─── src/components/schedule/scheduleUtils.js ────────────────────────────────
+
+export const DAYS_SHORT = ["S", "M", "T", "W", "T", "F", "S"];
+export const DAYS_FULL = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+export const MONTHS = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+
+export const HOUR_HEIGHT = 64;
+export const START_HOUR = 8;
+export const TIMELINE_HOURS = Array.from({ length: 10 }, (_, i) => i + START_HOUR);
+
+// Add new appointment types here — color flows everywhere automatically
+export const APPOINTMENT_TYPE_COLORS = {
+  "New Patient": { bg: "#FFF6D6", border: "#F5C842", text: "#7A5500", dot: "#F5C842" },
+  "Follow Up": { bg: "#D6E8FF", border: "#4A90D9", text: "#1A3A6B", dot: "#4A90D9" },
+  "Physical": { bg: "#EDD6FF", border: "#A855D4", text: "#4B0E72", dot: "#A855D4" },
+  "Consultation": { bg: "#FFD6F0", border: "#D455AA", text: "#6B0040", dot: "#D455AA" },
+  "Urgent Care": { bg: "#FFD6D6", border: "#D45555", text: "#6B0000", dot: "#D45555" },
+  "Default": { bg: "#D6F5E8", border: "#55A87A", text: "#0A4A28", dot: "#55A87A" },
+};
+
+export const APPOINTMENT_STATUS = {
+  Finished: { icon: "✓", color: "#34C759" },
+  Scheduled: { icon: "●", color: "#007AFF" },
+  Cancelled: { icon: "⊘", color: "#8E8E93" },
+};
+
+export function toDateString(year, month, day) {
+  return `${year}-${String(month + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+export function parseTimeToMinutes(timeStr) {
+  const [h, m] = timeStr.split(":").map(Number);
+  return h * 60 + m;
+}
+
+export function formatTime12h(timeStr) {
+  const [h, m] = timeStr.split(":").map(Number);
+  const period = h >= 12 ? "PM" : "AM";
+  const hour = h % 12 || 12;
+  return `${hour}:${String(m).padStart(2, "0")} ${period}`;
+}
+
+export function getDaysInMonth(year, month) {
+  return new Date(year, month + 1, 0).getDate();
+}
+
+export function getFirstDayOfMonth(year, month) {
+  return new Date(year, month, 1).getDay();
+}
+
+export function getWeekDates(dateStr) {
+  const d = new Date(dateStr + "T00:00:00");
+  const dow = d.getDay();
+  return Array.from({ length: 7 }, (_, i) => {
+    const nd = new Date(d);
+    nd.setDate(d.getDate() - dow + i);
+    return nd.toISOString().slice(0, 10);
+  });
+}
+
+export function getTodayString() {
+  const t = new Date();
+  return toDateString(t.getFullYear(), t.getMonth(), t.getDate());
+}
+
+export function getTypeColors(type) {
+  return APPOINTMENT_TYPE_COLORS[type] ?? APPOINTMENT_TYPE_COLORS["Default"];
+}
+
+export function groupAppointmentsByDate(appointments) {
+  return appointments.reduce((acc, a) => {
+    if (!acc[a.date]) acc[a.date] = [];
+    acc[a.date].push(a);
+    return acc;
+  }, {});
+}
+
+export function getTimelinePosition(startTime, endTime) {
+  const startMin = parseTimeToMinutes(startTime);
+  const endMin = parseTimeToMinutes(endTime);
+  const top = (startMin - START_HOUR * 60) * (HOUR_HEIGHT / 60);
+  const height = Math.max((endMin - startMin) * (HOUR_HEIGHT / 60), 32);
+  return { top, height };
+}

--- a/src/components/schedule/Timecolumn.jsx
+++ b/src/components/schedule/Timecolumn.jsx
@@ -1,0 +1,40 @@
+// ─── src/components/schedule/TimeColumn.jsx ──────────────────────────────────
+/**
+ * Left-side hour labels aligned to timeline grid rows.
+ *
+ * Props:
+ *   hours      {number[]}  e.g. [8, 9, 10, ..., 17]
+ *   hourHeight {number}    px height per hour row — must match the grid
+ */
+
+export default function TimeColumn({ hours, hourHeight }) {
+  return (
+    <div style={{ width: 44, flexShrink: 0 }}>
+      {hours.map((h) => {
+        const label =
+          h === 0 ? "12 AM"
+            : h < 12 ? `${h} AM`
+              : h === 12 ? "12 PM"
+                : `${h - 12} PM`;
+
+        return (
+          <div key={h} style={{ height: hourHeight, display: "flex", alignItems: "flex-start", paddingTop: 4 }}>
+            <span style={styles.label}>{label}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+const styles = {
+  label: {
+    fontSize: 10,
+    color: "#8E8E93",
+    textAlign: "right",
+    width: "100%",
+    paddingRight: 6,
+    fontFamily: "-apple-system, 'SF Pro Text', sans-serif",
+    lineHeight: 1,
+  },
+};

--- a/src/components/schedule/Viewswitcher.jsx
+++ b/src/components/schedule/Viewswitcher.jsx
@@ -1,0 +1,55 @@
+// ─── src/components/schedule/ViewSwitcher.jsx ────────────────────────────────
+/**
+ * Props:
+ *   activeView {string}   "month" | "week" | "day"
+ *   onChange   {function} (view: string) => void
+ */
+
+const VIEWS = ["month", "week", "day"];
+
+export default function ViewSwitcher({ activeView, onChange }) {
+  return (
+    <div style={styles.wrapper}>
+      {VIEWS.map((view) => {
+        const isActive = view === activeView;
+        return (
+          <button
+            key={view}
+            onClick={() => onChange(view)}
+            style={{
+              ...styles.btn,
+              background: isActive ? "#FFFFFF" : "transparent",
+              color: isActive ? "#007AFF" : "#8E8E93",
+              fontWeight: isActive ? 700 : 400,
+              boxShadow: isActive ? "0 1px 4px rgba(0,0,0,0.12)" : "none",
+            }}
+          >
+            {view.charAt(0).toUpperCase() + view.slice(1)}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+const styles = {
+  wrapper: {
+    display: "flex",
+    background: "#F2F2F7",
+    borderRadius: 10,
+    padding: 3,
+    margin: "8px 16px",
+    gap: 2,
+    flexShrink: 0,
+  },
+  btn: {
+    flex: 1,
+    padding: "7px 0",
+    border: "none",
+    borderRadius: 8,
+    fontSize: 13,
+    cursor: "pointer",
+    transition: "all 0.15s ease",
+    fontFamily: "-apple-system, 'SF Pro Text', sans-serif",
+  },
+};

--- a/src/components/schedule/Weekgrid.jsx
+++ b/src/components/schedule/Weekgrid.jsx
@@ -1,0 +1,146 @@
+// ─── src/components/schedule/WeekGrid.jsx ────────────────────────────────────
+/**
+ * 7-column scrollable week timeline.
+ *
+ * Props:
+ *   weekDates          {string[]}  7 "YYYY-MM-DD" strings Sun–Sat
+ *   selectedDate       {string}    "YYYY-MM-DD"
+ *   todayStr           {string}    "YYYY-MM-DD"
+ *   appointmentsByDate {object}    { "YYYY-MM-DD": [appointment, ...] }
+ *   onSelectDate       {function}  (dateStr) => void
+ *   onAppointmentPress {function}  (appointment) => void
+ */
+
+import AppointmentBlock from "./Appointmentblock";
+import TimeColumn from "./Timecolumn";
+import {
+  DAYS_SHORT,
+  TIMELINE_HOURS,
+  HOUR_HEIGHT,
+  START_HOUR,
+  getTimelinePosition,
+} from "./Scheduleutils";
+
+export default function WeekGrid({
+  weekDates, selectedDate, todayStr,
+  appointmentsByDate, onSelectDate, onAppointmentPress,
+}) {
+  return (
+    <div style={styles.wrapper}>
+      {/* Column headers */}
+      <div style={styles.headerRow}>
+        <div style={{ width: 44, flexShrink: 0 }} />
+        {weekDates.map((d, i) => {
+          const dayNum = new Date(d + "T00:00:00").getDate();
+          const isToday = d === todayStr;
+          const isSelected = d === selectedDate;
+          return (
+            <div
+              key={d}
+              onClick={() => onSelectDate(d)}
+              style={{
+                ...styles.dayHeader,
+                borderBottom: isSelected ? "2px solid #007AFF" : "2px solid transparent",
+              }}
+            >
+              <span style={styles.dayLabel}>{DAYS_SHORT[i]}</span>
+              <div style={{
+                ...styles.dayNum,
+                background: isToday ? "#007AFF" : "transparent",
+                color: isToday ? "#fff" : "#1C1C1E",
+                fontWeight: isToday ? 700 : 400,
+              }}>
+                {dayNum}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Scrollable time grid */}
+      <div style={styles.scrollArea}>
+        <div style={styles.gridBody}>
+          <TimeColumn hours={TIMELINE_HOURS} hourHeight={HOUR_HEIGHT} />
+
+          {weekDates.map((d) => {
+            const appts = (appointmentsByDate[d] ?? []).filter(
+              (a) => parseInt(a.startTime.split(":")[0]) >= START_HOUR
+            );
+            return (
+              <div key={d} style={styles.dayColumn}>
+                {TIMELINE_HOURS.map((h) => (
+                  <div key={h} style={{ height: HOUR_HEIGHT, borderBottom: "1px solid #F2F2F7" }} />
+                ))}
+                {appts.map((appt) => {
+                  const { top, height } = getTimelinePosition(appt.startTime, appt.endTime);
+                  return (
+                    <AppointmentBlock
+                      key={appt.id}
+                      appointment={appt}
+                      top={top}
+                      height={height}
+                      compact={true}
+                      onClick={onAppointmentPress}
+                    />
+                  );
+                })}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const styles = {
+  wrapper: {
+    display: "flex",
+    flexDirection: "column",
+    flex: 1,
+    overflow: "hidden",
+  },
+  headerRow: {
+    display: "flex",
+    borderBottom: "1px solid #E5E5EA",
+    flexShrink: 0,
+  },
+  dayHeader: {
+    flex: 1,
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    padding: "6px 0 4px",
+    cursor: "pointer",
+    gap: 2,
+  },
+  dayLabel: {
+    fontSize: 10,
+    color: "#8E8E93",
+    fontWeight: 600,
+    fontFamily: "-apple-system, 'SF Pro Text', sans-serif",
+  },
+  dayNum: {
+    width: 24,
+    height: 24,
+    borderRadius: "50%",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    fontSize: 12,
+    fontFamily: "-apple-system, 'SF Pro Text', sans-serif",
+  },
+  scrollArea: {
+    flex: 1,
+    overflowY: "auto",
+  },
+  gridBody: {
+    display: "flex",
+    position: "relative",
+  },
+  dayColumn: {
+    flex: 1,
+    position: "relative",
+    borderLeft: "1px solid #F2F2F7",
+  },
+};

--- a/src/screens/ScheduleScreen.jsx
+++ b/src/screens/ScheduleScreen.jsx
@@ -1,18 +1,198 @@
-const ScheduleScreen = () => {
+// ─── src/screens/ScheduleScreen.jsx ──────────────────────────────────────────
+/**
+ * Orchestrates all schedule components.
+ * Replace SAMPLE_APPOINTMENTS with your OSCAR API fetch when ready.
+ *
+ * Appointment shape:
+ *   {
+ *     id          {string|number}
+ *     patientName {string}    e.g. "Robert Brown"
+ *     type        {string}    e.g. "New Patient" | "Follow Up" | "Physical" | ...
+ *     date        {string}    "YYYY-MM-DD"
+ *     startTime   {string}    "HH:MM" 24-hour
+ *     endTime     {string}    "HH:MM" 24-hour
+ *     status      {string}    "Scheduled" | "Finished" | "Cancelled"
+ *   }
+ */
+
+import { useState, useMemo } from "react";
+import ViewSwitcher from "../components/schedule/Viewswitcher";
+import CalendarHeader from "../components/schedule/Calendarheader";
+import MonthGrid from "../components/schedule/Monthgrid";
+import WeekGrid from "../components/schedule/Weekgrid";
+import DayTimeline from "../components/schedule/Daytimeline";
+import {
+  MONTHS,
+  DAYS_FULL,
+  getTodayString,
+  getWeekDates,
+  groupAppointmentsByDate,
+} from "../components/schedule/Scheduleutils";
+
+// ─── Replace with API fetch when OSCAR backend is ready ──────────────────────
+const SAMPLE_APPOINTMENTS = [
+  { id: 1, patientName: "Robert Brown", type: "New Patient", date: "2026-04-15", startTime: "10:00", endTime: "11:00", status: "Finished" },
+  { id: 2, patientName: "Rohit Talwar", type: "Follow Up", date: "2026-04-15", startTime: "11:00", endTime: "12:30", status: "Scheduled" },
+  { id: 3, patientName: "Robert Brown", type: "Physical", date: "2026-04-15", startTime: "13:30", endTime: "14:00", status: "Finished" },
+  { id: 4, patientName: "Robert Brown", type: "New Patient", date: "2026-04-15", startTime: "14:00", endTime: "14:30", status: "Cancelled" },
+  { id: 5, patientName: "Robert Brown", type: "Consultation", date: "2026-04-15", startTime: "15:00", endTime: "15:30", status: "Scheduled" },
+  { id: 6, patientName: "Robert Brown", type: "Urgent Care", date: "2026-04-15", startTime: "15:30", endTime: "16:00", status: "Scheduled" },
+  { id: 7, patientName: "Robert Brown", type: "New Patient", date: "2026-04-13", startTime: "10:00", endTime: "11:30", status: "Finished" },
+  { id: 8, patientName: "Robert Brown", type: "Physical", date: "2026-04-13", startTime: "13:30", endTime: "14:30", status: "Scheduled" },
+  { id: 9, patientName: "Chris Konstas", type: "Follow Up", date: "2026-04-14", startTime: "11:00", endTime: "12:30", status: "Scheduled" },
+  { id: 10, patientName: "Robert Brown", type: "Consultation", date: "2026-04-16", startTime: "14:00", endTime: "15:00", status: "Scheduled" },
+  { id: 11, patientName: "Robert Brown", type: "New Patient", date: "2026-04-06", startTime: "09:00", endTime: "10:00", status: "Finished" },
+  { id: 12, patientName: "Robert Brown", type: "Follow Up", date: "2026-04-06", startTime: "10:00", endTime: "11:00", status: "Scheduled" },
+  { id: 13, patientName: "Robert Brown", type: "Physical", date: "2026-04-08", startTime: "09:00", endTime: "10:00", status: "Scheduled" },
+  { id: 14, patientName: "Robert Brown", type: "Consultation", date: "2026-04-08", startTime: "11:00", endTime: "12:00", status: "Scheduled" },
+  { id: 15, patientName: "Robert Brown", type: "New Patient", date: "2026-04-20", startTime: "09:00", endTime: "10:00", status: "Scheduled" },
+  { id: 16, patientName: "Robert Brown", type: "Follow Up", date: "2026-04-20", startTime: "10:00", endTime: "11:00", status: "Scheduled" },
+  { id: 17, patientName: "Robert Brown", type: "Physical", date: "2026-04-20", startTime: "11:00", endTime: "12:00", status: "Scheduled" },
+  { id: 18, patientName: "Robert Brown", type: "Consultation", date: "2026-04-20", startTime: "13:00", endTime: "14:00", status: "Scheduled" },
+];
+
+export default function ScheduleScreen({ appointments = SAMPLE_APPOINTMENTS }) {
+  const todayStr = getTodayString();
+
+  const [view, setView] = useState("month");
+  const [selectedDate, setSelectedDate] = useState("2026-04-15");
+  const [calYear, setCalYear] = useState(2026);
+  const [calMonth, setCalMonth] = useState(3); // 0-indexed: 3 = April
+
+  const appointmentsByDate = useMemo(
+    () => groupAppointmentsByDate(appointments),
+    [appointments]
+  );
+
+  // ── Navigation ──────────────────────────────────────────────────────────────
+
+  function handlePrev() {
+    if (view === "month") shiftMonth(-1);
+    else if (view === "week") shiftDays(-7);
+    else shiftDays(-1);
+  }
+
+  function handleNext() {
+    if (view === "month") shiftMonth(1);
+    else if (view === "week") shiftDays(7);
+    else shiftDays(1);
+  }
+
+  function shiftMonth(delta) {
+    let m = calMonth + delta;
+    let y = calYear;
+    if (m < 0) { m = 11; y--; }
+    if (m > 11) { m = 0; y++; }
+    setCalMonth(m);
+    setCalYear(y);
+  }
+
+  function shiftDays(days) {
+    const d = new Date(selectedDate + "T00:00:00");
+    d.setDate(d.getDate() + days);
+    const newDate = d.toISOString().slice(0, 10);
+    setSelectedDate(newDate);
+    setCalYear(d.getFullYear());
+    setCalMonth(d.getMonth());
+  }
+
+  // ── Select date → drill into Day view ──────────────────────────────────────
+
+  function handleSelectDate(dateStr) {
+    setSelectedDate(dateStr);
+    const d = new Date(dateStr + "T00:00:00");
+    setCalYear(d.getFullYear());
+    setCalMonth(d.getMonth());
+    setView("day");
+  }
+
+  // ── Header title per view ───────────────────────────────────────────────────
+
+  function getHeaderTitle() {
+    if (view === "month") return `${MONTHS[calMonth]} ${calYear}`;
+    if (view === "week") {
+      const dates = getWeekDates(selectedDate);
+      const start = new Date(dates[0] + "T00:00:00");
+      const end = new Date(dates[6] + "T00:00:00");
+      if (start.getMonth() === end.getMonth()) {
+        return `${MONTHS[start.getMonth()]} ${start.getFullYear()}`;
+      }
+      return `${MONTHS[start.getMonth()].slice(0, 3)} – ${MONTHS[end.getMonth()].slice(0, 3)} ${end.getFullYear()}`;
+    }
+    const d = new Date(selectedDate + "T00:00:00");
+    return `${DAYS_FULL[d.getDay()]} - ${MONTHS[d.getMonth()]} ${d.getDate()}, ${d.getFullYear()}`;
+  }
+
+  // ── Appointment tap → TODO: navigate to detail screen ──────────────────────
+
+  function handleAppointmentPress(appointment) {
+    console.log("Appointment pressed:", appointment);
+    // e.g. navigate(`/appointment/${appointment.id}`)
+  }
+
+  const weekDates = getWeekDates(selectedDate);
+  const dayAppointments = appointmentsByDate[selectedDate] ?? [];
+
   return (
-    <div style={styles.container}>
-      <h1>Schedule</h1>
+    <div style={styles.screen}>
+      <ViewSwitcher activeView={view} onChange={setView} />
+
+      <CalendarHeader
+        title={getHeaderTitle()}
+        onPrev={handlePrev}
+        onNext={handleNext}
+        onTitlePress={() => {/* TODO: open date picker */ }}
+      />
+
+      <div style={styles.content}>
+        {view === "month" && (
+          <MonthGrid
+            year={calYear}
+            month={calMonth}
+            selectedDate={selectedDate}
+            todayStr={todayStr}
+            appointmentsByDate={appointmentsByDate}
+            onSelectDate={handleSelectDate}
+            onAppointmentPress={handleAppointmentPress}
+          />
+        )}
+
+        {view === "week" && (
+          <WeekGrid
+            weekDates={weekDates}
+            selectedDate={selectedDate}
+            todayStr={todayStr}
+            appointmentsByDate={appointmentsByDate}
+            onSelectDate={handleSelectDate}
+            onAppointmentPress={handleAppointmentPress}
+          />
+        )}
+
+        {view === "day" && (
+          <DayTimeline
+            dateStr={selectedDate}
+            appointments={dayAppointments}
+            onAppointmentPress={handleAppointmentPress}
+          />
+        )}
+      </div>
     </div>
   );
-};
+}
 
 const styles = {
-  container: {
-    padding: "20px",
+  screen: {
     display: "flex",
-    justifyContent: "center",
-    minHeight: "calc(100vh - 80px)",
+    flexDirection: "column",
+    height: "calc(100vh - 80px)", // 80px = BottomTab height
+    background: "#FFFFFF",
+    fontFamily: "-apple-system, 'SF Pro Text', 'Helvetica Neue', sans-serif",
+    overflow: "hidden",
+  },
+  content: {
+    flex: 1,
+    display: "flex",
+    flexDirection: "column",
+    overflow: "hidden",
   },
 };
-
-export default ScheduleScreen;


### PR DESCRIPTION
## What's changed
- Added ScheduleScreen with 3 views: Month, Week, Day
- Created reusable schedule components:
  - ViewSwitcher
  - CalendarHeader
  - MonthGrid
  - WeekGrid
  - DayTimeline
  - AppointmentPill
  - AppointmentBlock
  - TimeColumn
  - scheduleUtils (shared constants & helpers)
- Updated App.jsx to handle full-height layout for schedule

## How to test
1. Run `npm run dev`
2. Sign in and click Schedule tab
3. Test Month / Week / Day toggle
4. Tap a date in Month view → should drill into Day view
5. Test prev/next arrows in all 3 views

## Notes
- Sample appointment data is hardcoded for now
- Will be replaced with OSCAR API fetch in a future PR