### PR TITLE
Feature/ schedule screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1430,7 +1429,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1472,7 +1470,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1578,7 +1575,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1813,7 +1809,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2500,7 +2495,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2562,7 +2556,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2572,7 +2565,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -2841,7 +2833,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -2963,7 +2954,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,34 +2,26 @@ import { Routes, Route, useLocation, Navigate } from "react-router-dom";
 import HomeScreen from "./screens/HomeScreen";
 import PatientsScreen from "./screens/PatientsScreen";
 import ScheduleScreen from "./screens/ScheduleScreen";
-import InboxScreen from "./screens/InboxScreen";
+import EditAppointmentScreen from "./screens/EditAppointmentScreen";
+import ChatScreen from "./screens/ChatScreen";
 import SplashScreen from "./screens/SplashScreen";
 import SignInScreen from "./screens/SignInScreen";
 import NotificationsScreen from "./screens/NotificationsScreen";
 import ProfileScreen from "./screens/ProfileScreen";
-import SettingsScreen from "./screens/SettingsScreen";
 import PatientRecordSummaryScreen from "./screens/PatientRecordSummaryScreen";
 import PatientRecordNotesScreen from "./screens/PatientRecordNotesScreen";
 import PatientRecordHistoryScreen from "./screens/PatientRecordHistoryScreen";
 import PatientRecordVitalsScreen from "./screens/PatientRecordVitalsScreen";
 import ClinicalNoteScreen from "./screens/ClinicalNoteScreen";
 import BottomTab from "./components/BottomTab";
-import ScrollToTop from "./components/ScrollToTop";
 
-/**
- * Main App Component
- * Handles routing and conditional rendering of bottom tab navigation
- * Navigation flow: / -> /splash (3s) -> /signin -> /home
- */
 function App() {
   const location = useLocation();
 
-  // No bottom tab navigation screens
-  const routesWithoutBottomTab = ["/splash", "/signin"];
+  const routesWithoutBottomTab = ["/splash", "/signin", "/appointment/edit"];
   const shouldShowBottomTab = !routesWithoutBottomTab.includes(location.pathname);
 
-  // No vertical scrolling screens (schedule manages its own internal scroll)
-  const noScrollRoutes = ["/splash", "/signin", "/schedule"];
+  const noScrollRoutes = ["/splash", "/signin", "/schedule", "/appointment/edit"];
   const shouldDisableScroll = noScrollRoutes.includes(location.pathname);
 
   return (
@@ -40,7 +32,6 @@ function App() {
       height: shouldDisableScroll ? "100vh" : "auto",
       minHeight: shouldDisableScroll ? "unset" : "100vh",
     }}>
-      <ScrollToTop />
       <Routes>
         <Route path="/" element={<Navigate to="/splash" replace />} />
         <Route path="/splash" element={<SplashScreen />} />
@@ -48,10 +39,10 @@ function App() {
         <Route path="/home" element={<HomeScreen />} />
         <Route path="/patients" element={<PatientsScreen />} />
         <Route path="/schedule" element={<ScheduleScreen />} />
-        <Route path="/inbox" element={<InboxScreen />} />
+        <Route path="/appointment/edit" element={<EditAppointmentScreen />} />
+        <Route path="/chat" element={<ChatScreen />} />
         <Route path="/notifications" element={<NotificationsScreen />} />
         <Route path="/profile" element={<ProfileScreen />} />
-        <Route path="/settings" element={<SettingsScreen />} />
         <Route path="/patient/:id/summary" element={<PatientRecordSummaryScreen />} />
         <Route path="/patient/:id/notes" element={<PatientRecordNotesScreen />} />
         <Route path="/patient/:id/history" element={<PatientRecordHistoryScreen />} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,11 +3,11 @@ import HomeScreen from "./screens/HomeScreen";
 import PatientsScreen from "./screens/PatientsScreen";
 import ScheduleScreen from "./screens/ScheduleScreen";
 import EditAppointmentScreen from "./screens/EditAppointmentScreen";
-import ChatScreen from "./screens/ChatScreen";
+import InboxScreen from "./screens/InboxScreen";
 import SplashScreen from "./screens/SplashScreen";
 import SignInScreen from "./screens/SignInScreen";
-import NotificationsScreen from "./screens/NotificationsScreen";
 import ProfileScreen from "./screens/ProfileScreen";
+import SettingsScreen from "./screens/SettingsScreen";
 import PatientRecordSummaryScreen from "./screens/PatientRecordSummaryScreen";
 import PatientRecordNotesScreen from "./screens/PatientRecordNotesScreen";
 import PatientRecordHistoryScreen from "./screens/PatientRecordHistoryScreen";
@@ -40,9 +40,9 @@ function App() {
         <Route path="/patients" element={<PatientsScreen />} />
         <Route path="/schedule" element={<ScheduleScreen />} />
         <Route path="/appointment/edit" element={<EditAppointmentScreen />} />
-        <Route path="/chat" element={<ChatScreen />} />
-        <Route path="/notifications" element={<NotificationsScreen />} />
+        <Route path="/inbox" element={<InboxScreen />} />
         <Route path="/profile" element={<ProfileScreen />} />
+        <Route path="/settings" element={<SettingsScreen />} />
         <Route path="/patient/:id/summary" element={<PatientRecordSummaryScreen />} />
         <Route path="/patient/:id/notes" element={<PatientRecordNotesScreen />} />
         <Route path="/patient/:id/history" element={<PatientRecordHistoryScreen />} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,14 +28,14 @@ function App() {
   const routesWithoutBottomTab = ["/splash", "/signin"];
   const shouldShowBottomTab = !routesWithoutBottomTab.includes(location.pathname);
 
-  // No vertical scrolling screens
-  const noScrollRoutes = ["/splash", "/signin"];
+  // No vertical scrolling screens (schedule manages its own internal scroll)
+  const noScrollRoutes = ["/splash", "/signin", "/schedule"];
   const shouldDisableScroll = noScrollRoutes.includes(location.pathname);
 
   return (
     <div style={{
       ...styles.appContainer,
-      paddingBottom: shouldShowBottomTab ? "80px" : "0",
+      paddingBottom: shouldShowBottomTab && !shouldDisableScroll ? "80px" : "0",
       overflow: shouldDisableScroll ? "hidden" : "auto",
       height: shouldDisableScroll ? "100vh" : "auto",
       minHeight: shouldDisableScroll ? "unset" : "100vh",

--- a/src/components/schedule/AppointmentForm.jsx
+++ b/src/components/schedule/AppointmentForm.jsx
@@ -1,0 +1,355 @@
+// ─── src/components/schedule/AppointmentForm.jsx ─────────────────────────────
+
+import { APPOINTMENT_TYPE_COLORS, APPOINTMENT_STATUS } from "./Scheduleutils";
+
+const APPOINTMENT_TYPES = Object.keys(APPOINTMENT_TYPE_COLORS);
+const STATUSES = Object.keys(APPOINTMENT_STATUS);
+const DURATIONS = ["15 min", "30 min", "45 min", "60 min", "90 min"];
+
+const MONTHS_LIST = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+const DAYS = Array.from({ length: 31 }, (_, i) => i + 1);
+const YEARS = Array.from({ length: 10 }, (_, i) => 2024 + i);
+const HOURS = Array.from({ length: 12 }, (_, i) => String(i + 1).padStart(2, "0"));
+const MINUTES = ["00", "15", "30", "45"];
+const PERIODS = ["AM", "PM"];
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function parseDateStr(dateStr) {
+  // dateStr = "YYYY-MM-DD"
+  if (!dateStr) return { day: "1", month: "0", year: String(new Date().getFullYear()) };
+  const [y, m, d] = dateStr.split("-");
+  return { year: y, month: String(parseInt(m) - 1), day: String(parseInt(d)) };
+}
+
+function buildDateStr(year, month, day) {
+  return `${year}-${String(parseInt(month) + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+function parseTimeStr(timeStr) {
+  // timeStr = "HH:MM" 24h
+  if (!timeStr) return { hour: "12", minute: "00", period: "PM" };
+  const [h, m] = timeStr.split(":").map(Number);
+  const period = h >= 12 ? "PM" : "AM";
+  const hour = h % 12 || 12;
+  return { hour: String(hour).padStart(2, "0"), minute: String(m).padStart(2, "0"), period };
+}
+
+function buildTimeStr(hour, minute, period) {
+  let h = parseInt(hour);
+  if (period === "PM" && h !== 12) h += 12;
+  if (period === "AM" && h === 12) h = 0;
+  return `${String(h).padStart(2, "0")}:${minute}`;
+}
+
+// ── AppointmentForm ──────────────────────────────────────────────────────────
+
+export default function AppointmentForm({ formData, onChange, onAddNote, previousNotes = [] }) {
+  const dateParts = parseDateStr(formData.date);
+  const timeParts = parseTimeStr(formData.startTime);
+
+  function handleDatePart(part, value) {
+    const updated = { ...dateParts, [part]: value };
+    onChange("date", buildDateStr(updated.year, updated.month, updated.day));
+  }
+
+  function handleTimePart(part, value) {
+    const updated = { ...timeParts, [part]: value };
+    onChange("startTime", buildTimeStr(updated.hour, updated.minute, updated.period));
+  }
+
+  return (
+    <div style={styles.wrapper}>
+      {/* ── Section heading ── */}
+      <p style={styles.sectionTitle}>Appointment Details</p>
+      <div style={styles.divider} />
+
+      {/* ── Type + Status ── */}
+      <div style={styles.row}>
+        <div style={styles.fieldHalf}>
+          <label style={styles.label}>Appointment Type</label>
+          <Select
+            value={formData.type}
+            onChange={(v) => onChange("type", v)}
+            placeholder="Select Type"
+            options={APPOINTMENT_TYPES}
+          />
+        </div>
+        <div style={styles.fieldHalf}>
+          <label style={styles.label}>Status</label>
+          <Select
+            value={formData.status}
+            onChange={(v) => onChange("status", v)}
+            placeholder="Select Status"
+            options={STATUSES}
+          />
+        </div>
+      </div>
+
+      {/* ── Date — 3 dropdowns ── */}
+      <div style={styles.field}>
+        <label style={styles.label}>Date</label>
+        <div style={styles.row}>
+          {/* Month */}
+          <Select
+            value={dateParts.month}
+            onChange={(v) => handleDatePart("month", v)}
+            options={MONTHS_LIST.map((m, i) => ({ label: m, value: String(i) }))}
+            style={{ flex: 1.4 }}
+          />
+          {/* Day */}
+          <Select
+            value={dateParts.day}
+            onChange={(v) => handleDatePart("day", v)}
+            options={DAYS.map((d) => ({ label: String(d), value: String(d) }))}
+            style={{ flex: 1 }}
+          />
+          {/* Year */}
+          <Select
+            value={dateParts.year}
+            onChange={(v) => handleDatePart("year", v)}
+            options={YEARS.map((y) => ({ label: String(y), value: String(y) }))}
+            style={{ flex: 1.2 }}
+          />
+        </div>
+      </div>
+
+      {/* ── Time + Duration ── */}
+      <div style={styles.row}>
+        <div style={styles.fieldHalf}>
+          <label style={styles.label}>Time</label>
+          <div style={styles.row}>
+            <Select
+              value={timeParts.hour}
+              onChange={(v) => handleTimePart("hour", v)}
+              options={HOURS.map((h) => ({ label: h, value: h }))}
+              style={{ flex: 1 }}
+            />
+            <Select
+              value={timeParts.minute}
+              onChange={(v) => handleTimePart("minute", v)}
+              options={MINUTES.map((m) => ({ label: m, value: m }))}
+              style={{ flex: 1 }}
+            />
+            <Select
+              value={timeParts.period}
+              onChange={(v) => handleTimePart("period", v)}
+              options={PERIODS.map((p) => ({ label: p, value: p }))}
+              style={{ flex: 1 }}
+            />
+          </div>
+        </div>
+
+        <div style={styles.fieldHalf}>
+          <label style={styles.label}>Duration</label>
+          <Select
+            value={formData.duration}
+            onChange={(v) => onChange("duration", v)}
+            options={DURATIONS}
+          />
+        </div>
+      </div>
+
+      {/* ── Reason for Visit ── */}
+      <div style={styles.field}>
+        <label style={styles.label}>Reason for Visit</label>
+        <textarea
+          value={formData.reasonForVisit}
+          onChange={(e) => onChange("reasonForVisit", e.target.value)}
+          placeholder="Reason for visit..."
+          rows={4}
+          style={styles.textarea}
+        />
+      </div>
+
+      {/* ── Add Note ── */}
+      <button onClick={onAddNote} style={styles.addNoteBtn}>
+        + Add Note
+      </button>
+
+      {/* ── Previous notes ── */}
+      {previousNotes.map((note, i) => (
+        <div key={i} style={styles.noteCard}>
+          <div style={styles.noteHeader}>
+            <span style={styles.noteDate}>{note.date}</span>
+            <span style={styles.noteDoctor}>{note.doctor}</span>
+            <span style={styles.syncBadge}>Synced</span>
+          </div>
+          <p style={styles.noteType}>{note.type}</p>
+          <p style={styles.noteText}>{note.text}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Reusable Select dropdown ─────────────────────────────────────────────────
+
+function Select({ value, onChange, options, placeholder, style = {} }) {
+  // options can be strings OR { label, value } objects
+  const normalized = options.map((o) =>
+    typeof o === "string" ? { label: o, value: o } : o
+  );
+
+  return (
+    <div style={{ ...styles.selectWrapper, ...style }}>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        style={styles.select}
+      >
+        {placeholder && <option value="">{placeholder}</option>}
+        {normalized.map((o) => (
+          <option key={o.value} value={o.value}>{o.label}</option>
+        ))}
+      </select>
+      <span style={styles.selectArrow}>▼</span>
+    </div>
+  );
+}
+
+// ── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = {
+  wrapper: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 14,
+    background: "#FFFFFF",
+    borderRadius: 12,
+    padding: 16,
+  },
+  sectionTitle: {
+    fontSize: 15,
+    fontWeight: 700,
+    color: "#007AFF",
+    margin: 0,
+    fontFamily: "-apple-system, 'SF Pro Text', sans-serif",
+  },
+  divider: {
+    height: 1,
+    background: "#007AFF",
+    marginTop: -10,
+  },
+  row: {
+    display: "flex",
+    gap: 8,
+  },
+  field: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 6,
+  },
+  fieldHalf: {
+    flex: 1,
+    display: "flex",
+    flexDirection: "column",
+    gap: 6,
+  },
+  label: {
+    fontSize: 12,
+    fontWeight: 600,
+    color: "#3C3C43",
+    fontFamily: "-apple-system, 'SF Pro Text', sans-serif",
+  },
+  selectWrapper: {
+    position: "relative",
+    display: "flex",
+    alignItems: "center",
+    flex: 1,
+  },
+  select: {
+    width: "100%",
+    padding: "9px 24px 9px 10px",
+    border: "1.5px solid #E5E5EA",
+    borderRadius: 8,
+    fontSize: 13,
+    color: "#1C1C1E",
+    background: "#FFFFFF",
+    appearance: "none",
+    WebkitAppearance: "none",
+    fontFamily: "-apple-system, 'SF Pro Text', sans-serif",
+    cursor: "pointer",
+    outline: "none",
+  },
+  selectArrow: {
+    position: "absolute",
+    right: 7,
+    fontSize: 8,
+    color: "#8E8E93",
+    pointerEvents: "none",
+  },
+  textarea: {
+    width: "100%",
+    padding: "10px 12px",
+    border: "1.5px solid #E5E5EA",
+    borderRadius: 8,
+    fontSize: 13,
+    color: "#1C1C1E",
+    resize: "none",
+    fontFamily: "-apple-system, 'SF Pro Text', sans-serif",
+    boxSizing: "border-box",
+    outline: "none",
+  },
+  addNoteBtn: {
+    width: "100%",
+    padding: "12px 0",
+    border: "1.5px solid #E5E5EA",
+    borderRadius: 10,
+    background: "#FFFFFF",
+    fontSize: 14,
+    fontWeight: 600,
+    color: "#1C1C1E",
+    cursor: "pointer",
+    fontFamily: "-apple-system, 'SF Pro Text', sans-serif",
+  },
+  noteCard: {
+    background: "#F9F9F9",
+    borderRadius: 10,
+    padding: "12px 14px",
+    display: "flex",
+    flexDirection: "column",
+    gap: 4,
+  },
+  noteHeader: {
+    display: "flex",
+    alignItems: "center",
+    gap: 8,
+  },
+  noteDate: {
+    fontSize: 12,
+    color: "#3C3C43",
+    fontFamily: "-apple-system, 'SF Pro Text', sans-serif",
+  },
+  noteDoctor: {
+    fontSize: 12,
+    color: "#3C3C43",
+    fontFamily: "-apple-system, 'SF Pro Text', sans-serif",
+  },
+  syncBadge: {
+    fontSize: 10,
+    fontWeight: 700,
+    color: "#FFFFFF",
+    background: "#34C759",
+    borderRadius: 4,
+    padding: "2px 6px",
+    fontFamily: "-apple-system, 'SF Pro Text', sans-serif",
+  },
+  noteType: {
+    fontSize: 12,
+    fontWeight: 600,
+    color: "#007AFF",
+    margin: 0,
+    fontFamily: "-apple-system, 'SF Pro Text', sans-serif",
+  },
+  noteText: {
+    fontSize: 12,
+    color: "#8E8E93",
+    margin: 0,
+    fontFamily: "-apple-system, 'SF Pro Text', sans-serif",
+  },
+};

--- a/src/components/schedule/Appointmentblock.jsx
+++ b/src/components/schedule/Appointmentblock.jsx
@@ -1,0 +1,129 @@
+// ─── src/components/schedule/AppointmentBlock.jsx ────────────────────────────
+/**
+ * Absolutely-positioned block rendered inside a timeline column.
+ *
+ * Props:
+ *   appointment {object}   { id, patientName, type, startTime, endTime, status }
+ *   top         {number}   px offset from top of timeline
+ *   height      {number}   px height of the block
+ *   compact     {boolean}  true = week view (less space), false = day view
+ *   onClick     {function} (appointment) => void
+ */
+
+import { getTypeColors, formatTime12h, APPOINTMENT_STATUS } from "./Scheduleutils";
+
+export default function AppointmentBlock({ appointment, top, height, compact = false, onClick }) {
+  const colors = getTypeColors(appointment.type);
+  const isCancelled = appointment.status === "Cancelled";
+  const statusCfg = APPOINTMENT_STATUS[appointment.status] ?? APPOINTMENT_STATUS["Scheduled"];
+
+  const shortName = (() => {
+    const parts = appointment.patientName.trim().split(" ");
+    return parts.length >= 2
+      ? `${parts[0][0]}. ${parts[parts.length - 1]}`
+      : appointment.patientName;
+  })();
+
+  return (
+    <button
+      onClick={() => onClick?.(appointment)}
+      title={`${appointment.patientName} — ${appointment.type} @ ${formatTime12h(appointment.startTime)}`}
+      style={{
+        ...styles.block,
+        top,
+        height,
+        background: isCancelled ? "#F2F2F7" : colors.bg,
+        borderLeft: `3px solid ${isCancelled ? "#C7C7CC" : colors.border}`,
+        opacity: isCancelled ? 0.65 : 1,
+      }}
+    >
+      {/* Time — shown only in day view */}
+      {!compact && (
+        <span style={{ ...styles.time, color: isCancelled ? "#8E8E93" : colors.text }}>
+          {formatTime12h(appointment.startTime)}
+        </span>
+      )}
+
+      {/* Patient name */}
+      <span style={{
+        ...styles.name,
+        color: isCancelled ? "#8E8E93" : colors.text,
+        fontSize: compact ? 9 : 12,
+      }}>
+        {compact ? shortName : appointment.patientName}
+      </span>
+
+      {/* Appointment type — only if tall enough */}
+      {height > 36 && (
+        <span style={{
+          ...styles.type,
+          color: isCancelled ? "#8E8E93" : colors.text,
+          fontSize: compact ? 8 : 10,
+        }}>
+          {appointment.type}
+        </span>
+      )}
+
+      {/* Status — day view only, tall enough */}
+      {!compact && height > 52 && (
+        <span style={{ ...styles.status, color: statusCfg.color }}>
+          {statusCfg.icon} {appointment.status}
+        </span>
+      )}
+
+      {/* Status dot — compact (week) view */}
+      {compact && height > 44 && (
+        <span style={{ fontSize: 8, color: statusCfg.color, lineHeight: 1 }}>
+          {statusCfg.icon}
+        </span>
+      )}
+    </button>
+  );
+}
+
+const styles = {
+  block: {
+    position: "absolute",
+    left: 2,
+    right: 2,
+    border: "none",
+    borderRadius: 6,
+    padding: "4px 6px",
+    cursor: "pointer",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "flex-start",
+    overflow: "hidden",
+    textAlign: "left",
+    boxShadow: "0 1px 3px rgba(0,0,0,0.06)",
+    fontFamily: "-apple-system, 'SF Pro Text', sans-serif",
+    gap: 1,
+  },
+  time: {
+    fontSize: 10,
+    fontWeight: 500,
+    lineHeight: 1.3,
+  },
+  name: {
+    fontWeight: 700,
+    lineHeight: 1.3,
+    whiteSpace: "nowrap",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    width: "100%",
+  },
+  type: {
+    opacity: 0.8,
+    lineHeight: 1.2,
+    whiteSpace: "nowrap",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    width: "100%",
+  },
+  status: {
+    fontSize: 10,
+    fontWeight: 500,
+    marginTop: 2,
+    lineHeight: 1,
+  },
+};

--- a/src/components/schedule/Appointmentpill.jsx
+++ b/src/components/schedule/Appointmentpill.jsx
@@ -1,0 +1,55 @@
+// ─── src/components/schedule/AppointmentPill.jsx ─────────────────────────────
+/**
+ * Small colored label shown inside month grid cells.
+ *
+ * Props:
+ *   appointment {object}   { id, patientName, type, status }
+ *   onClick     {function} (appointment) => void
+ */
+
+import { getTypeColors } from "./Scheduleutils";
+
+export default function AppointmentPill({ appointment, onClick }) {
+  const colors = getTypeColors(appointment.type);
+  const isCancelled = appointment.status === "Cancelled";
+
+  const nameParts = appointment.patientName.trim().split(" ");
+  const shortName =
+    nameParts.length >= 2
+      ? `${nameParts[0][0]}. ${nameParts[nameParts.length - 1]}`
+      : appointment.patientName;
+
+  return (
+    <button
+      onClick={() => onClick?.(appointment)}
+      title={`${appointment.patientName} — ${appointment.type}`}
+      style={{
+        ...styles.pill,
+        background: isCancelled ? "#F2F2F7" : colors.bg,
+        color: isCancelled ? "#8E8E93" : colors.text,
+        textDecoration: isCancelled ? "line-through" : "none",
+      }}
+    >
+      {shortName}
+    </button>
+  );
+}
+
+const styles = {
+  pill: {
+    display: "block",
+    width: "100%",
+    fontSize: 8.5,
+    fontWeight: 600,
+    borderRadius: 3,
+    padding: "1.5px 4px",
+    border: "none",
+    cursor: "pointer",
+    textAlign: "left",
+    overflow: "hidden",
+    whiteSpace: "nowrap",
+    textOverflow: "ellipsis",
+    lineHeight: 1.4,
+    fontFamily: "-apple-system, 'SF Pro Text', sans-serif",
+  },
+};

--- a/src/components/schedule/Calendarheader.jsx
+++ b/src/components/schedule/Calendarheader.jsx
@@ -1,0 +1,61 @@
+// ─── src/components/schedule/CalendarHeader.jsx ──────────────────────────────
+/**
+ * Props:
+ *   title        {string}   e.g. "April 2026" or "Wednesday - April 15, 2026"
+ *   onPrev       {function} called when left arrow tapped
+ *   onNext       {function} called when right arrow tapped
+ *   onTitlePress {function} called when title tapped (e.g. open date picker)
+ */
+
+export default function CalendarHeader({ title, onPrev, onNext, onTitlePress }) {
+  return (
+    <div style={styles.wrapper}>
+      <button onClick={onPrev} style={styles.arrow} aria-label="Previous">‹</button>
+
+      <button onClick={onTitlePress} style={styles.title} aria-label="Select date">
+        {title}
+        <span style={styles.caret}>▼</span>
+      </button>
+
+      <button onClick={onNext} style={styles.arrow} aria-label="Next">›</button>
+    </div>
+  );
+}
+
+const styles = {
+  wrapper: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    padding: "10px 16px 6px",
+    flexShrink: 0,
+  },
+  arrow: {
+    background: "none",
+    border: "none",
+    fontSize: 26,
+    color: "#007AFF",
+    cursor: "pointer",
+    padding: "0 8px",
+    lineHeight: 1,
+    borderRadius: 6,
+  },
+  title: {
+    background: "none",
+    border: "none",
+    fontSize: 18,
+    fontWeight: 700,
+    color: "#1C1C1E",
+    cursor: "pointer",
+    display: "flex",
+    alignItems: "center",
+    gap: 6,
+    fontFamily: "-apple-system, 'SF Pro Display', sans-serif",
+    padding: 0,
+  },
+  caret: {
+    fontSize: 10,
+    color: "#8E8E93",
+    marginTop: 2,
+  },
+};

--- a/src/components/schedule/CancelConfirmModal.jsx
+++ b/src/components/schedule/CancelConfirmModal.jsx
@@ -1,0 +1,103 @@
+// ─── src/components/schedule/CancelConfirmModal.jsx ──────────────────────────
+/**
+ * Confirmation modal shown when user taps "Cancel Appointment"
+ *
+ * Props:
+ *   appointment {object}   the appointment being cancelled
+ *   onConfirm   {function} called when user taps "Yes"
+ *   onDismiss   {function} called when user taps "Cancel"
+ */
+
+import { formatTime12h, MONTHS } from "./Scheduleutils";
+
+export default function CancelConfirmModal({ appointment, onConfirm, onDismiss }) {
+  if (!appointment) return null;
+
+  const date = new Date(appointment.date + "T00:00:00");
+  const formattedDate = `${MONTHS[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()}`;
+  const formattedTime = formatTime12h(appointment.startTime);
+
+  return (
+    // Backdrop
+    <div style={styles.backdrop} onClick={onDismiss}>
+      {/* Modal box — stop click from closing when clicking inside */}
+      <div style={styles.modal} onClick={(e) => e.stopPropagation()}>
+        <p style={styles.title}>Are you sure you want to cancel an appointment?</p>
+
+        <p style={styles.detail}>ID: {appointment.patientId ?? "P-0021"} {appointment.patientName}</p>
+        <p style={styles.detail}>{appointment.type}</p>
+        <p style={styles.detail}>{formattedDate} {formattedTime}</p>
+
+        <div style={styles.actions}>
+          <button onClick={onConfirm} style={styles.yesBtn}>Yes</button>
+          <button onClick={onDismiss} style={styles.cancelBtn}>Cancel</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const styles = {
+  backdrop: {
+    position: "fixed",
+    inset: 0,
+    background: "rgba(0,0,0,0.4)",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    zIndex: 1000,
+    padding: "0 24px",
+  },
+  modal: {
+    background: "#FFFFFF",
+    borderRadius: 14,
+    padding: "24px 20px 20px",
+    width: "100%",
+    maxWidth: 340,
+    boxShadow: "0 8px 32px rgba(0,0,0,0.18)",
+    textAlign: "center",
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: 700,
+    color: "#1C1C1E",
+    marginBottom: 16,
+    lineHeight: 1.4,
+    fontFamily: "-apple-system, 'SF Pro Text', sans-serif",
+  },
+  detail: {
+    fontSize: 14,
+    color: "#3C3C43",
+    margin: "2px 0",
+    fontFamily: "-apple-system, 'SF Pro Text', sans-serif",
+  },
+  actions: {
+    display: "flex",
+    gap: 12,
+    marginTop: 20,
+  },
+  yesBtn: {
+    flex: 1,
+    padding: "12px 0",
+    background: "#D9534F",
+    color: "#FFFFFF",
+    border: "none",
+    borderRadius: 10,
+    fontSize: 15,
+    fontWeight: 700,
+    cursor: "pointer",
+    fontFamily: "-apple-system, 'SF Pro Text', sans-serif",
+  },
+  cancelBtn: {
+    flex: 1,
+    padding: "12px 0",
+    background: "#FFFFFF",
+    color: "#1C1C1E",
+    border: "1.5px solid #C7C7CC",
+    borderRadius: 10,
+    fontSize: 15,
+    fontWeight: 600,
+    cursor: "pointer",
+    fontFamily: "-apple-system, 'SF Pro Text', sans-serif",
+  },
+};

--- a/src/components/schedule/Daytimeline.jsx
+++ b/src/components/schedule/Daytimeline.jsx
@@ -1,0 +1,68 @@
+// ─── src/components/schedule/DayTimeline.jsx ─────────────────────────────────
+/**
+ * Single-day scrollable timeline.
+ *
+ * Props:
+ *   dateStr            {string}   "YYYY-MM-DD"
+ *   appointments       {array}    appointments for this day
+ *   onAppointmentPress {function} (appointment) => void
+ */
+
+import AppointmentBlock from "./Appointmentblock";
+import TimeColumn from "./Timecolumn";
+import {
+  TIMELINE_HOURS,
+  HOUR_HEIGHT,
+  START_HOUR,
+  getTimelinePosition,
+} from "./Scheduleutils";
+
+export default function DayTimeline({ appointments = [], onAppointmentPress }) {
+  const visibleAppts = appointments.filter(
+    (a) => parseInt(a.startTime.split(":")[0]) >= START_HOUR
+  );
+
+  return (
+    <div style={styles.scrollArea}>
+      <div style={styles.body}>
+        <TimeColumn hours={TIMELINE_HOURS} hourHeight={HOUR_HEIGHT} />
+
+        <div style={styles.eventsColumn}>
+          {TIMELINE_HOURS.map((h) => (
+            <div key={h} style={{ height: HOUR_HEIGHT, borderBottom: "1px solid #F2F2F7" }} />
+          ))}
+
+          {visibleAppts.map((appt) => {
+            const { top, height } = getTimelinePosition(appt.startTime, appt.endTime);
+            return (
+              <AppointmentBlock
+                key={appt.id}
+                appointment={appt}
+                top={top}
+                height={height}
+                compact={false}
+                onClick={onAppointmentPress}
+              />
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const styles = {
+  scrollArea: {
+    flex: 1,
+    overflowY: "auto",
+  },
+  body: {
+    display: "flex",
+    position: "relative",
+  },
+  eventsColumn: {
+    flex: 1,
+    position: "relative",
+    borderLeft: "1px solid #E5E5EA",
+  },
+};

--- a/src/components/schedule/Monthgrid.jsx
+++ b/src/components/schedule/Monthgrid.jsx
@@ -1,0 +1,160 @@
+// ─── src/components/schedule/MonthGrid.jsx ───────────────────────────────────
+/**
+ * Full monthly calendar grid with appointment pills.
+ *
+ * Props:
+ *   year               {number}   e.g. 2026
+ *   month              {number}   0-indexed
+ *   selectedDate       {string}   "YYYY-MM-DD"
+ *   todayStr           {string}   "YYYY-MM-DD"
+ *   appointmentsByDate {object}   { "YYYY-MM-DD": [appointment, ...] }
+ *   onSelectDate       {function} (dateStr) => void
+ *   onAppointmentPress {function} (appointment) => void
+ */
+
+import AppointmentPill from "./Appointmentpill";
+import {
+  DAYS_SHORT,
+  getDaysInMonth,
+  getFirstDayOfMonth,
+  toDateString,
+} from "./Scheduleutils";
+
+const MAX_PILLS = 3;
+
+export default function MonthGrid({
+  year, month, selectedDate, todayStr,
+  appointmentsByDate, onSelectDate, onAppointmentPress,
+}) {
+  const daysInMonth = getDaysInMonth(year, month);
+  const firstDay = getFirstDayOfMonth(year, month);
+  const prevMonDays = getDaysInMonth(year, month === 0 ? 11 : month - 1);
+
+  // Build 42-cell grid (6 rows × 7 cols)
+  const cells = [];
+  for (let i = 0; i < firstDay; i++) {
+    cells.push({ day: prevMonDays - firstDay + 1 + i, isCurrent: false, dateStr: null });
+  }
+  for (let d = 1; d <= daysInMonth; d++) {
+    cells.push({ day: d, isCurrent: true, dateStr: toDateString(year, month, d) });
+  }
+  for (let d = 1; d <= 42 - cells.length; d++) {
+    cells.push({ day: d, isCurrent: false, dateStr: null });
+  }
+
+  return (
+    <div style={styles.wrapper}>
+      {/* Day-of-week header row */}
+      <div style={styles.headerRow}>
+        {DAYS_SHORT.map((d, i) => (
+          <div key={i} style={styles.headerCell}>{d}</div>
+        ))}
+      </div>
+
+      {/* Calendar grid */}
+      <div style={styles.grid}>
+        {cells.map((cell, i) => {
+          const isToday = cell.dateStr === todayStr;
+          const isSelected = cell.dateStr === selectedDate;
+          const appts = cell.dateStr ? (appointmentsByDate[cell.dateStr] ?? []) : [];
+          const shown = appts.slice(0, MAX_PILLS);
+          const overflow = appts.length - MAX_PILLS;
+
+          return (
+            <div
+              key={i}
+              onClick={() => cell.isCurrent && cell.dateStr && onSelectDate(cell.dateStr)}
+              style={{
+                ...styles.cell,
+                cursor: cell.isCurrent ? "pointer" : "default",
+                background: isSelected && cell.isCurrent ? "#EEF4FF" : "transparent",
+              }}
+            >
+              <div style={{
+                ...styles.dayNum,
+                background: isToday ? "#007AFF" : "transparent",
+                color: isToday ? "#fff" : cell.isCurrent ? "#1C1C1E" : "#C7C7CC",
+                fontWeight: isToday ? 700 : 400,
+              }}>
+                {cell.day}
+              </div>
+
+              <div style={styles.pills}>
+                {shown.map((appt) => (
+                  <AppointmentPill
+                    key={appt.id}
+                    appointment={appt}
+                    onClick={onAppointmentPress}
+                  />
+                ))}
+                {overflow > 0 && (
+                  <span style={styles.overflow}>+{overflow} more</span>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+const styles = {
+  wrapper: {
+    display: "flex",
+    flexDirection: "column",
+    flex: 1,
+    padding: "0 6px",
+    overflow: "hidden",
+  },
+  headerRow: {
+    display: "grid",
+    gridTemplateColumns: "repeat(7, 1fr)",
+    marginBottom: 2,
+    flexShrink: 0,
+  },
+  headerCell: {
+    textAlign: "center",
+    fontSize: 11,
+    fontWeight: 600,
+    color: "#8E8E93",
+    padding: "4px 0",
+    fontFamily: "-apple-system, 'SF Pro Text', sans-serif",
+  },
+  grid: {
+    display: "grid",
+    gridTemplateColumns: "repeat(7, 1fr)",
+    flex: 1,
+    overflow: "hidden",
+  },
+  cell: {
+    minHeight: 56,
+    padding: "2px 2px 4px",
+    display: "flex",
+    flexDirection: "column",
+    gap: 1,
+    borderRadius: 6,
+  },
+  dayNum: {
+    width: 22,
+    height: 22,
+    borderRadius: "50%",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    fontSize: 12,
+    margin: "0 auto 2px",
+    fontFamily: "-apple-system, 'SF Pro Text', sans-serif",
+  },
+  pills: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 1,
+  },
+  overflow: {
+    fontSize: 7.5,
+    color: "#8E8E93",
+    paddingLeft: 3,
+    fontFamily: "-apple-system, 'SF Pro Text', sans-serif",
+  },
+};

--- a/src/components/schedule/Scheduleutils.js
+++ b/src/components/schedule/Scheduleutils.js
@@ -1,0 +1,87 @@
+// ─── src/components/schedule/scheduleUtils.js ────────────────────────────────
+
+export const DAYS_SHORT = ["S", "M", "T", "W", "T", "F", "S"];
+export const DAYS_FULL = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+export const MONTHS = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+
+export const HOUR_HEIGHT = 64;
+export const START_HOUR = 8;
+export const TIMELINE_HOURS = Array.from({ length: 10 }, (_, i) => i + START_HOUR);
+
+// Add new appointment types here — color flows everywhere automatically
+export const APPOINTMENT_TYPE_COLORS = {
+  "New Patient": { bg: "#FFF6D6", border: "#F5C842", text: "#7A5500", dot: "#F5C842" },
+  "Follow Up": { bg: "#D6E8FF", border: "#4A90D9", text: "#1A3A6B", dot: "#4A90D9" },
+  "Physical": { bg: "#EDD6FF", border: "#A855D4", text: "#4B0E72", dot: "#A855D4" },
+  "Consultation": { bg: "#FFD6F0", border: "#D455AA", text: "#6B0040", dot: "#D455AA" },
+  "Urgent Care": { bg: "#FFD6D6", border: "#D45555", text: "#6B0000", dot: "#D45555" },
+  "Default": { bg: "#D6F5E8", border: "#55A87A", text: "#0A4A28", dot: "#55A87A" },
+};
+
+export const APPOINTMENT_STATUS = {
+  Finished: { icon: "✓", color: "#34C759" },
+  Scheduled: { icon: "●", color: "#007AFF" },
+  Cancelled: { icon: "⊘", color: "#8E8E93" },
+};
+
+export function toDateString(year, month, day) {
+  return `${year}-${String(month + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+export function parseTimeToMinutes(timeStr) {
+  const [h, m] = timeStr.split(":").map(Number);
+  return h * 60 + m;
+}
+
+export function formatTime12h(timeStr) {
+  const [h, m] = timeStr.split(":").map(Number);
+  const period = h >= 12 ? "PM" : "AM";
+  const hour = h % 12 || 12;
+  return `${hour}:${String(m).padStart(2, "0")} ${period}`;
+}
+
+export function getDaysInMonth(year, month) {
+  return new Date(year, month + 1, 0).getDate();
+}
+
+export function getFirstDayOfMonth(year, month) {
+  return new Date(year, month, 1).getDay();
+}
+
+export function getWeekDates(dateStr) {
+  const d = new Date(dateStr + "T00:00:00");
+  const dow = d.getDay();
+  return Array.from({ length: 7 }, (_, i) => {
+    const nd = new Date(d);
+    nd.setDate(d.getDate() - dow + i);
+    return nd.toISOString().slice(0, 10);
+  });
+}
+
+export function getTodayString() {
+  const t = new Date();
+  return toDateString(t.getFullYear(), t.getMonth(), t.getDate());
+}
+
+export function getTypeColors(type) {
+  return APPOINTMENT_TYPE_COLORS[type] ?? APPOINTMENT_TYPE_COLORS["Default"];
+}
+
+export function groupAppointmentsByDate(appointments) {
+  return appointments.reduce((acc, a) => {
+    if (!acc[a.date]) acc[a.date] = [];
+    acc[a.date].push(a);
+    return acc;
+  }, {});
+}
+
+export function getTimelinePosition(startTime, endTime) {
+  const startMin = parseTimeToMinutes(startTime);
+  const endMin = parseTimeToMinutes(endTime);
+  const top = (startMin - START_HOUR * 60) * (HOUR_HEIGHT / 60);
+  const height = Math.max((endMin - startMin) * (HOUR_HEIGHT / 60), 32);
+  return { top, height };
+}

--- a/src/components/schedule/Timecolumn.jsx
+++ b/src/components/schedule/Timecolumn.jsx
@@ -1,0 +1,40 @@
+// ─── src/components/schedule/TimeColumn.jsx ──────────────────────────────────
+/**
+ * Left-side hour labels aligned to timeline grid rows.
+ *
+ * Props:
+ *   hours      {number[]}  e.g. [8, 9, 10, ..., 17]
+ *   hourHeight {number}    px height per hour row — must match the grid
+ */
+
+export default function TimeColumn({ hours, hourHeight }) {
+  return (
+    <div style={{ width: 44, flexShrink: 0 }}>
+      {hours.map((h) => {
+        const label =
+          h === 0 ? "12 AM"
+            : h < 12 ? `${h} AM`
+              : h === 12 ? "12 PM"
+                : `${h - 12} PM`;
+
+        return (
+          <div key={h} style={{ height: hourHeight, display: "flex", alignItems: "flex-start", paddingTop: 4 }}>
+            <span style={styles.label}>{label}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+const styles = {
+  label: {
+    fontSize: 10,
+    color: "#8E8E93",
+    textAlign: "right",
+    width: "100%",
+    paddingRight: 6,
+    fontFamily: "-apple-system, 'SF Pro Text', sans-serif",
+    lineHeight: 1,
+  },
+};

--- a/src/components/schedule/Viewswitcher.jsx
+++ b/src/components/schedule/Viewswitcher.jsx
@@ -1,0 +1,55 @@
+// ─── src/components/schedule/ViewSwitcher.jsx ────────────────────────────────
+/**
+ * Props:
+ *   activeView {string}   "month" | "week" | "day"
+ *   onChange   {function} (view: string) => void
+ */
+
+const VIEWS = ["month", "week", "day"];
+
+export default function ViewSwitcher({ activeView, onChange }) {
+  return (
+    <div style={styles.wrapper}>
+      {VIEWS.map((view) => {
+        const isActive = view === activeView;
+        return (
+          <button
+            key={view}
+            onClick={() => onChange(view)}
+            style={{
+              ...styles.btn,
+              background: isActive ? "#FFFFFF" : "transparent",
+              color: isActive ? "#007AFF" : "#8E8E93",
+              fontWeight: isActive ? 700 : 400,
+              boxShadow: isActive ? "0 1px 4px rgba(0,0,0,0.12)" : "none",
+            }}
+          >
+            {view.charAt(0).toUpperCase() + view.slice(1)}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+const styles = {
+  wrapper: {
+    display: "flex",
+    background: "#F2F2F7",
+    borderRadius: 10,
+    padding: 3,
+    margin: "8px 16px",
+    gap: 2,
+    flexShrink: 0,
+  },
+  btn: {
+    flex: 1,
+    padding: "7px 0",
+    border: "none",
+    borderRadius: 8,
+    fontSize: 13,
+    cursor: "pointer",
+    transition: "all 0.15s ease",
+    fontFamily: "-apple-system, 'SF Pro Text', sans-serif",
+  },
+};

--- a/src/components/schedule/Weekgrid.jsx
+++ b/src/components/schedule/Weekgrid.jsx
@@ -1,0 +1,146 @@
+// ─── src/components/schedule/WeekGrid.jsx ────────────────────────────────────
+/**
+ * 7-column scrollable week timeline.
+ *
+ * Props:
+ *   weekDates          {string[]}  7 "YYYY-MM-DD" strings Sun–Sat
+ *   selectedDate       {string}    "YYYY-MM-DD"
+ *   todayStr           {string}    "YYYY-MM-DD"
+ *   appointmentsByDate {object}    { "YYYY-MM-DD": [appointment, ...] }
+ *   onSelectDate       {function}  (dateStr) => void
+ *   onAppointmentPress {function}  (appointment) => void
+ */
+
+import AppointmentBlock from "./Appointmentblock";
+import TimeColumn from "./Timecolumn";
+import {
+  DAYS_SHORT,
+  TIMELINE_HOURS,
+  HOUR_HEIGHT,
+  START_HOUR,
+  getTimelinePosition,
+} from "./Scheduleutils";
+
+export default function WeekGrid({
+  weekDates, selectedDate, todayStr,
+  appointmentsByDate, onSelectDate, onAppointmentPress,
+}) {
+  return (
+    <div style={styles.wrapper}>
+      {/* Column headers */}
+      <div style={styles.headerRow}>
+        <div style={{ width: 44, flexShrink: 0 }} />
+        {weekDates.map((d, i) => {
+          const dayNum = new Date(d + "T00:00:00").getDate();
+          const isToday = d === todayStr;
+          const isSelected = d === selectedDate;
+          return (
+            <div
+              key={d}
+              onClick={() => onSelectDate(d)}
+              style={{
+                ...styles.dayHeader,
+                borderBottom: isSelected ? "2px solid #007AFF" : "2px solid transparent",
+              }}
+            >
+              <span style={styles.dayLabel}>{DAYS_SHORT[i]}</span>
+              <div style={{
+                ...styles.dayNum,
+                background: isToday ? "#007AFF" : "transparent",
+                color: isToday ? "#fff" : "#1C1C1E",
+                fontWeight: isToday ? 700 : 400,
+              }}>
+                {dayNum}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Scrollable time grid */}
+      <div style={styles.scrollArea}>
+        <div style={styles.gridBody}>
+          <TimeColumn hours={TIMELINE_HOURS} hourHeight={HOUR_HEIGHT} />
+
+          {weekDates.map((d) => {
+            const appts = (appointmentsByDate[d] ?? []).filter(
+              (a) => parseInt(a.startTime.split(":")[0]) >= START_HOUR
+            );
+            return (
+              <div key={d} style={styles.dayColumn}>
+                {TIMELINE_HOURS.map((h) => (
+                  <div key={h} style={{ height: HOUR_HEIGHT, borderBottom: "1px solid #F2F2F7" }} />
+                ))}
+                {appts.map((appt) => {
+                  const { top, height } = getTimelinePosition(appt.startTime, appt.endTime);
+                  return (
+                    <AppointmentBlock
+                      key={appt.id}
+                      appointment={appt}
+                      top={top}
+                      height={height}
+                      compact={true}
+                      onClick={onAppointmentPress}
+                    />
+                  );
+                })}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const styles = {
+  wrapper: {
+    display: "flex",
+    flexDirection: "column",
+    flex: 1,
+    overflow: "hidden",
+  },
+  headerRow: {
+    display: "flex",
+    borderBottom: "1px solid #E5E5EA",
+    flexShrink: 0,
+  },
+  dayHeader: {
+    flex: 1,
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    padding: "6px 0 4px",
+    cursor: "pointer",
+    gap: 2,
+  },
+  dayLabel: {
+    fontSize: 10,
+    color: "#8E8E93",
+    fontWeight: 600,
+    fontFamily: "-apple-system, 'SF Pro Text', sans-serif",
+  },
+  dayNum: {
+    width: 24,
+    height: 24,
+    borderRadius: "50%",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    fontSize: 12,
+    fontFamily: "-apple-system, 'SF Pro Text', sans-serif",
+  },
+  scrollArea: {
+    flex: 1,
+    overflowY: "auto",
+  },
+  gridBody: {
+    display: "flex",
+    position: "relative",
+  },
+  dayColumn: {
+    flex: 1,
+    position: "relative",
+    borderLeft: "1px solid #F2F2F7",
+  },
+};

--- a/src/screens/EditAppointmentScreen.jsx
+++ b/src/screens/EditAppointmentScreen.jsx
@@ -1,0 +1,228 @@
+// ─── src/screens/EditAppointmentScreen.jsx ───────────────────────────────────
+/**
+ * Edit Appointment Screen
+ *
+ * Opened when user taps an appointment block in the schedule.
+ * Appointment data is passed via React Router location state:
+ *
+ *   navigate("/appointment/edit", { state: { appointment } })
+ *
+ * On Save & Sync → TODO: call OSCAR API, then go back
+ * On Cancel Appointment → shows confirmation modal → goes back
+ */
+
+import { useState } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
+import AppointmentForm from "../components/schedule/AppointmentForm";
+import CancelConfirmModal from "../components/schedule/CancelConfirmModal";
+
+// ─── Sample previous notes — replace with API data later ─────────────────────
+const SAMPLE_NOTES = [
+  {
+    date: "Feb 9, 2026",
+    doctor: "Dr. Lee",
+    type: "SOAP Note",
+    text: "Follow-up for diabetes management...",
+  },
+];
+
+export default function EditAppointmentScreen() {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  // Appointment passed from ScheduleScreen via navigation state
+  const incoming = location.state?.appointment;
+
+  // ── Form state — pre-filled from incoming appointment ──────────────────────
+  const [formData, setFormData] = useState({
+    type: incoming?.type ?? "",
+    status: incoming?.status ?? "Scheduled",
+    date: incoming?.date ?? "",
+    startTime: incoming?.startTime ?? "12:00",
+    duration: incoming?.duration ?? "30 min",
+    reasonForVisit: incoming?.reasonForVisit ?? "",
+  });
+
+  const [showCancelModal, setShowCancelModal] = useState(false);
+
+  // ── Handlers ────────────────────────────────────────────────────────────────
+
+  function handleFieldChange(field, value) {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+  }
+
+  function handleSaveAndSync() {
+    // TODO: call OSCAR API with formData
+    console.log("Saving appointment:", formData);
+    navigate(-1);
+  }
+
+  function handleCancelConfirm() {
+    // TODO: call OSCAR API to cancel appointment
+    console.log("Appointment cancelled");
+    setShowCancelModal(false);
+    navigate(-1);
+  }
+
+  // Build appointment object for the modal summary
+  const appointmentForModal = {
+    ...incoming,
+    ...formData,
+    patientId: incoming?.patientId ?? "—",
+    patientName: incoming?.patientName ?? "Unknown",
+  };
+
+  return (
+    <div style={styles.screen}>
+      {/* ── Header ── */}
+      <div style={styles.header}>
+        <button onClick={() => navigate(-1)} style={styles.backBtn}>←</button>
+        <span style={styles.headerTitle}>Edit Appointment</span>
+        <div style={{ width: 32 }} />
+      </div>
+
+      {/* ── Scrollable body ── */}
+      <div style={styles.body}>
+
+        {/* Patient info card — uses real data from appointment */}
+        <div style={styles.patientCard}>
+          <p style={styles.patientName}>
+            {incoming?.patientName ?? "Unknown"}
+          </p>
+          {incoming?.patientId && (
+            <p style={styles.patientMeta}>ID: {incoming.patientId}</p>
+          )}
+          {(incoming?.age || incoming?.gender) && (
+            <p style={styles.patientMeta}>
+              {incoming?.age ? `${incoming.age} years old` : ""}
+              {incoming?.age && incoming?.gender ? " • " : ""}
+              {incoming?.gender ?? ""}
+            </p>
+          )}
+          {incoming?.dob && (
+            <p style={styles.patientMeta}>DOB: {incoming.dob}</p>
+          )}
+        </div>
+
+        {/* Appointment form */}
+        <AppointmentForm
+          formData={formData}
+          onChange={handleFieldChange}
+          onAddNote={() => console.log("Add note tapped")}
+          previousNotes={SAMPLE_NOTES}
+        />
+
+        {/* Action buttons */}
+        <button onClick={handleSaveAndSync} style={styles.saveBtn}>
+          Save &amp; Sync
+        </button>
+
+        <button
+          onClick={() => setShowCancelModal(true)}
+          style={styles.cancelApptBtn}
+        >
+          Cancel Appointment
+        </button>
+      </div>
+
+      {/* Cancel confirmation modal */}
+      {showCancelModal && (
+        <CancelConfirmModal
+          appointment={appointmentForModal}
+          onConfirm={handleCancelConfirm}
+          onDismiss={() => setShowCancelModal(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+const styles = {
+  screen: {
+    display: "flex",
+    flexDirection: "column",
+    height: "100vh",
+    background: "#F2F2F7",
+    fontFamily: "-apple-system, 'SF Pro Text', 'Helvetica Neue', sans-serif",
+    overflow: "hidden",
+  },
+  header: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    padding: "14px 16px",
+    background: "#FFFFFF",
+    borderBottom: "1px solid #E5E5EA",
+    flexShrink: 0,
+  },
+  backBtn: {
+    background: "none",
+    border: "none",
+    fontSize: 20,
+    color: "#007AFF",
+    cursor: "pointer",
+    padding: 0,
+    width: 32,
+    fontFamily: "-apple-system, 'SF Pro Text', sans-serif",
+  },
+  headerTitle: {
+    fontSize: 16,
+    fontWeight: 700,
+    color: "#1C1C1E",
+    fontFamily: "-apple-system, 'SF Pro Display', sans-serif",
+  },
+  body: {
+    flex: 1,
+    overflowY: "auto",
+    padding: "16px",
+    display: "flex",
+    flexDirection: "column",
+    gap: 16,
+  },
+  patientCard: {
+    background: "#FFFFFF",
+    borderRadius: 12,
+    padding: "14px 16px",
+    display: "flex",
+    flexDirection: "column",
+    gap: 3,
+  },
+  patientName: {
+    fontSize: 16,
+    fontWeight: 700,
+    color: "#1C1C1E",
+    margin: 0,
+    fontFamily: "-apple-system, 'SF Pro Display', sans-serif",
+  },
+  patientMeta: {
+    fontSize: 13,
+    color: "#8E8E93",
+    margin: 0,
+    fontFamily: "-apple-system, 'SF Pro Text', sans-serif",
+  },
+  saveBtn: {
+    width: "100%",
+    padding: "15px 0",
+    background: "#007AFF",
+    color: "#FFFFFF",
+    border: "none",
+    borderRadius: 12,
+    fontSize: 15,
+    fontWeight: 700,
+    cursor: "pointer",
+    fontFamily: "-apple-system, 'SF Pro Text', sans-serif",
+  },
+  cancelApptBtn: {
+    width: "100%",
+    padding: "15px 0",
+    background: "#D9534F",
+    color: "#FFFFFF",
+    border: "none",
+    borderRadius: 12,
+    fontSize: 15,
+    fontWeight: 700,
+    cursor: "pointer",
+    fontFamily: "-apple-system, 'SF Pro Text', sans-serif",
+    marginBottom: 8,
+  },
+};

--- a/src/screens/ScheduleScreen.jsx
+++ b/src/screens/ScheduleScreen.jsx
@@ -1,18 +1,198 @@
-const ScheduleScreen = () => {
+// ─── src/screens/ScheduleScreen.jsx ──────────────────────────────────────────
+/**
+ * Orchestrates all schedule components.
+ * Replace SAMPLE_APPOINTMENTS with your OSCAR API fetch when ready.
+ *
+ * Appointment shape:
+ *   {
+ *     id          {string|number}
+ *     patientName {string}    e.g. "Robert Brown"
+ *     type        {string}    e.g. "New Patient" | "Follow Up" | "Physical" | ...
+ *     date        {string}    "YYYY-MM-DD"
+ *     startTime   {string}    "HH:MM" 24-hour
+ *     endTime     {string}    "HH:MM" 24-hour
+ *     status      {string}    "Scheduled" | "Finished" | "Cancelled"
+ *   }
+ */
+
+import { useState, useMemo } from "react";
+import ViewSwitcher from "../components/schedule/Viewswitcher";
+import CalendarHeader from "../components/schedule/Calendarheader";
+import MonthGrid from "../components/schedule/Monthgrid";
+import WeekGrid from "../components/schedule/Weekgrid";
+import DayTimeline from "../components/schedule/Daytimeline";
+import {
+  MONTHS,
+  DAYS_FULL,
+  getTodayString,
+  getWeekDates,
+  groupAppointmentsByDate,
+} from "../components/schedule/Scheduleutils";
+
+// ─── Replace with API fetch when OSCAR backend is ready ──────────────────────
+const SAMPLE_APPOINTMENTS = [
+  { id: 1, patientName: "Robert Brown", type: "New Patient", date: "2026-04-15", startTime: "10:00", endTime: "11:00", status: "Finished" },
+  { id: 2, patientName: "Rohit Talwar", type: "Follow Up", date: "2026-04-15", startTime: "11:00", endTime: "12:30", status: "Scheduled" },
+  { id: 3, patientName: "Robert Brown", type: "Physical", date: "2026-04-15", startTime: "13:30", endTime: "14:00", status: "Finished" },
+  { id: 4, patientName: "Robert Brown", type: "New Patient", date: "2026-04-15", startTime: "14:00", endTime: "14:30", status: "Cancelled" },
+  { id: 5, patientName: "Robert Brown", type: "Consultation", date: "2026-04-15", startTime: "15:00", endTime: "15:30", status: "Scheduled" },
+  { id: 6, patientName: "Robert Brown", type: "Urgent Care", date: "2026-04-15", startTime: "15:30", endTime: "16:00", status: "Scheduled" },
+  { id: 7, patientName: "Robert Brown", type: "New Patient", date: "2026-04-13", startTime: "10:00", endTime: "11:30", status: "Finished" },
+  { id: 8, patientName: "Robert Brown", type: "Physical", date: "2026-04-13", startTime: "13:30", endTime: "14:30", status: "Scheduled" },
+  { id: 9, patientName: "Chris Konstas", type: "Follow Up", date: "2026-04-14", startTime: "11:00", endTime: "12:30", status: "Scheduled" },
+  { id: 10, patientName: "Robert Brown", type: "Consultation", date: "2026-04-16", startTime: "14:00", endTime: "15:00", status: "Scheduled" },
+  { id: 11, patientName: "Robert Brown", type: "New Patient", date: "2026-04-06", startTime: "09:00", endTime: "10:00", status: "Finished" },
+  { id: 12, patientName: "Robert Brown", type: "Follow Up", date: "2026-04-06", startTime: "10:00", endTime: "11:00", status: "Scheduled" },
+  { id: 13, patientName: "Robert Brown", type: "Physical", date: "2026-04-08", startTime: "09:00", endTime: "10:00", status: "Scheduled" },
+  { id: 14, patientName: "Robert Brown", type: "Consultation", date: "2026-04-08", startTime: "11:00", endTime: "12:00", status: "Scheduled" },
+  { id: 15, patientName: "Robert Brown", type: "New Patient", date: "2026-04-20", startTime: "09:00", endTime: "10:00", status: "Scheduled" },
+  { id: 16, patientName: "Robert Brown", type: "Follow Up", date: "2026-04-20", startTime: "10:00", endTime: "11:00", status: "Scheduled" },
+  { id: 17, patientName: "Robert Brown", type: "Physical", date: "2026-04-20", startTime: "11:00", endTime: "12:00", status: "Scheduled" },
+  { id: 18, patientName: "Robert Brown", type: "Consultation", date: "2026-04-20", startTime: "13:00", endTime: "14:00", status: "Scheduled" },
+];
+
+export default function ScheduleScreen({ appointments = SAMPLE_APPOINTMENTS }) {
+  const todayStr = getTodayString();
+
+  const [view, setView] = useState("month");
+  const [selectedDate, setSelectedDate] = useState("2026-04-15");
+  const [calYear, setCalYear] = useState(2026);
+  const [calMonth, setCalMonth] = useState(3); // 0-indexed: 3 = April
+
+  const appointmentsByDate = useMemo(
+    () => groupAppointmentsByDate(appointments),
+    [appointments]
+  );
+
+  // ── Navigation ──────────────────────────────────────────────────────────────
+
+  function handlePrev() {
+    if (view === "month") shiftMonth(-1);
+    else if (view === "week") shiftDays(-7);
+    else shiftDays(-1);
+  }
+
+  function handleNext() {
+    if (view === "month") shiftMonth(1);
+    else if (view === "week") shiftDays(7);
+    else shiftDays(1);
+  }
+
+  function shiftMonth(delta) {
+    let m = calMonth + delta;
+    let y = calYear;
+    if (m < 0) { m = 11; y--; }
+    if (m > 11) { m = 0; y++; }
+    setCalMonth(m);
+    setCalYear(y);
+  }
+
+  function shiftDays(days) {
+    const d = new Date(selectedDate + "T00:00:00");
+    d.setDate(d.getDate() + days);
+    const newDate = d.toISOString().slice(0, 10);
+    setSelectedDate(newDate);
+    setCalYear(d.getFullYear());
+    setCalMonth(d.getMonth());
+  }
+
+  // ── Select date → drill into Day view ──────────────────────────────────────
+
+  function handleSelectDate(dateStr) {
+    setSelectedDate(dateStr);
+    const d = new Date(dateStr + "T00:00:00");
+    setCalYear(d.getFullYear());
+    setCalMonth(d.getMonth());
+    setView("day");
+  }
+
+  // ── Header title per view ───────────────────────────────────────────────────
+
+  function getHeaderTitle() {
+    if (view === "month") return `${MONTHS[calMonth]} ${calYear}`;
+    if (view === "week") {
+      const dates = getWeekDates(selectedDate);
+      const start = new Date(dates[0] + "T00:00:00");
+      const end = new Date(dates[6] + "T00:00:00");
+      if (start.getMonth() === end.getMonth()) {
+        return `${MONTHS[start.getMonth()]} ${start.getFullYear()}`;
+      }
+      return `${MONTHS[start.getMonth()].slice(0, 3)} – ${MONTHS[end.getMonth()].slice(0, 3)} ${end.getFullYear()}`;
+    }
+    const d = new Date(selectedDate + "T00:00:00");
+    return `${DAYS_FULL[d.getDay()]} - ${MONTHS[d.getMonth()]} ${d.getDate()}, ${d.getFullYear()}`;
+  }
+
+  // ── Appointment tap → TODO: navigate to detail screen ──────────────────────
+
+  function handleAppointmentPress(appointment) {
+    console.log("Appointment pressed:", appointment);
+    // e.g. navigate(`/appointment/${appointment.id}`)
+  }
+
+  const weekDates = getWeekDates(selectedDate);
+  const dayAppointments = appointmentsByDate[selectedDate] ?? [];
+
   return (
-    <div style={styles.container}>
-      <h1>Schedule</h1>
+    <div style={styles.screen}>
+      <ViewSwitcher activeView={view} onChange={setView} />
+
+      <CalendarHeader
+        title={getHeaderTitle()}
+        onPrev={handlePrev}
+        onNext={handleNext}
+        onTitlePress={() => {/* TODO: open date picker */ }}
+      />
+
+      <div style={styles.content}>
+        {view === "month" && (
+          <MonthGrid
+            year={calYear}
+            month={calMonth}
+            selectedDate={selectedDate}
+            todayStr={todayStr}
+            appointmentsByDate={appointmentsByDate}
+            onSelectDate={handleSelectDate}
+            onAppointmentPress={handleAppointmentPress}
+          />
+        )}
+
+        {view === "week" && (
+          <WeekGrid
+            weekDates={weekDates}
+            selectedDate={selectedDate}
+            todayStr={todayStr}
+            appointmentsByDate={appointmentsByDate}
+            onSelectDate={handleSelectDate}
+            onAppointmentPress={handleAppointmentPress}
+          />
+        )}
+
+        {view === "day" && (
+          <DayTimeline
+            dateStr={selectedDate}
+            appointments={dayAppointments}
+            onAppointmentPress={handleAppointmentPress}
+          />
+        )}
+      </div>
     </div>
   );
-};
+}
 
 const styles = {
-  container: {
-    padding: "20px",
+  screen: {
     display: "flex",
-    justifyContent: "center",
-    minHeight: "calc(100vh - 80px)",
+    flexDirection: "column",
+    height: "calc(100vh - 80px)", // 80px = BottomTab height
+    background: "#FFFFFF",
+    fontFamily: "-apple-system, 'SF Pro Text', 'Helvetica Neue', sans-serif",
+    overflow: "hidden",
+  },
+  content: {
+    flex: 1,
+    display: "flex",
+    flexDirection: "column",
+    overflow: "hidden",
   },
 };
-
-export default ScheduleScreen;

--- a/src/screens/ScheduleScreen.jsx
+++ b/src/screens/ScheduleScreen.jsx
@@ -1,26 +1,12 @@
 // ─── src/screens/ScheduleScreen.jsx ──────────────────────────────────────────
-/**
- * Orchestrates all schedule components.
- * Replace SAMPLE_APPOINTMENTS with your OSCAR API fetch when ready.
- *
- * Appointment shape:
- *   {
- *     id          {string|number}
- *     patientName {string}    e.g. "Robert Brown"
- *     type        {string}    e.g. "New Patient" | "Follow Up" | "Physical" | ...
- *     date        {string}    "YYYY-MM-DD"
- *     startTime   {string}    "HH:MM" 24-hour
- *     endTime     {string}    "HH:MM" 24-hour
- *     status      {string}    "Scheduled" | "Finished" | "Cancelled"
- *   }
- */
 
 import { useState, useMemo } from "react";
-import ViewSwitcher from "../components/schedule/Viewswitcher";
-import CalendarHeader from "../components/schedule/Calendarheader";
-import MonthGrid from "../components/schedule/Monthgrid";
-import WeekGrid from "../components/schedule/Weekgrid";
-import DayTimeline from "../components/schedule/Daytimeline";
+import { useNavigate } from "react-router-dom";
+import ViewSwitcher from "../components/schedule/ViewSwitcher";
+import CalendarHeader from "../components/schedule/CalendarHeader";
+import MonthGrid from "../components/schedule/MonthGrid";
+import WeekGrid from "../components/schedule/WeekGrid";
+import DayTimeline from "../components/schedule/DayTimeline";
 import {
   MONTHS,
   DAYS_FULL,
@@ -32,14 +18,14 @@ import {
 // ─── Replace with API fetch when OSCAR backend is ready ──────────────────────
 const SAMPLE_APPOINTMENTS = [
   { id: 1, patientName: "Robert Brown", type: "New Patient", date: "2026-04-15", startTime: "10:00", endTime: "11:00", status: "Finished" },
-  { id: 2, patientName: "Rohit Talwar", type: "Follow Up", date: "2026-04-15", startTime: "11:00", endTime: "12:30", status: "Scheduled" },
+  { id: 2, patientName: "Jane Doe", type: "Follow Up", date: "2026-04-15", startTime: "11:00", endTime: "12:30", status: "Scheduled" },
   { id: 3, patientName: "Robert Brown", type: "Physical", date: "2026-04-15", startTime: "13:30", endTime: "14:00", status: "Finished" },
   { id: 4, patientName: "Robert Brown", type: "New Patient", date: "2026-04-15", startTime: "14:00", endTime: "14:30", status: "Cancelled" },
   { id: 5, patientName: "Robert Brown", type: "Consultation", date: "2026-04-15", startTime: "15:00", endTime: "15:30", status: "Scheduled" },
   { id: 6, patientName: "Robert Brown", type: "Urgent Care", date: "2026-04-15", startTime: "15:30", endTime: "16:00", status: "Scheduled" },
   { id: 7, patientName: "Robert Brown", type: "New Patient", date: "2026-04-13", startTime: "10:00", endTime: "11:30", status: "Finished" },
   { id: 8, patientName: "Robert Brown", type: "Physical", date: "2026-04-13", startTime: "13:30", endTime: "14:30", status: "Scheduled" },
-  { id: 9, patientName: "Chris Konstas", type: "Follow Up", date: "2026-04-14", startTime: "11:00", endTime: "12:30", status: "Scheduled" },
+  { id: 9, patientName: "Jane Doe", type: "Follow Up", date: "2026-04-14", startTime: "11:00", endTime: "12:30", status: "Scheduled" },
   { id: 10, patientName: "Robert Brown", type: "Consultation", date: "2026-04-16", startTime: "14:00", endTime: "15:00", status: "Scheduled" },
   { id: 11, patientName: "Robert Brown", type: "New Patient", date: "2026-04-06", startTime: "09:00", endTime: "10:00", status: "Finished" },
   { id: 12, patientName: "Robert Brown", type: "Follow Up", date: "2026-04-06", startTime: "10:00", endTime: "11:00", status: "Scheduled" },
@@ -52,12 +38,13 @@ const SAMPLE_APPOINTMENTS = [
 ];
 
 export default function ScheduleScreen({ appointments = SAMPLE_APPOINTMENTS }) {
+  const navigate = useNavigate();
   const todayStr = getTodayString();
 
   const [view, setView] = useState("month");
   const [selectedDate, setSelectedDate] = useState("2026-04-15");
   const [calYear, setCalYear] = useState(2026);
-  const [calMonth, setCalMonth] = useState(3); // 0-indexed: 3 = April
+  const [calMonth, setCalMonth] = useState(3);
 
   const appointmentsByDate = useMemo(
     () => groupAppointmentsByDate(appointments),
@@ -96,8 +83,6 @@ export default function ScheduleScreen({ appointments = SAMPLE_APPOINTMENTS }) {
     setCalMonth(d.getMonth());
   }
 
-  // ── Select date → drill into Day view ──────────────────────────────────────
-
   function handleSelectDate(dateStr) {
     setSelectedDate(dateStr);
     const d = new Date(dateStr + "T00:00:00");
@@ -106,7 +91,13 @@ export default function ScheduleScreen({ appointments = SAMPLE_APPOINTMENTS }) {
     setView("day");
   }
 
-  // ── Header title per view ───────────────────────────────────────────────────
+  // ── Tapping an appointment → go to Edit screen ─────────────────────────────
+
+  function handleAppointmentPress(appointment) {
+    navigate("/appointment/edit", { state: { appointment } });
+  }
+
+  // ── Header title ────────────────────────────────────────────────────────────
 
   function getHeaderTitle() {
     if (view === "month") return `${MONTHS[calMonth]} ${calYear}`;
@@ -123,13 +114,6 @@ export default function ScheduleScreen({ appointments = SAMPLE_APPOINTMENTS }) {
     return `${DAYS_FULL[d.getDay()]} - ${MONTHS[d.getMonth()]} ${d.getDate()}, ${d.getFullYear()}`;
   }
 
-  // ── Appointment tap → TODO: navigate to detail screen ──────────────────────
-
-  function handleAppointmentPress(appointment) {
-    console.log("Appointment pressed:", appointment);
-    // e.g. navigate(`/appointment/${appointment.id}`)
-  }
-
   const weekDates = getWeekDates(selectedDate);
   const dayAppointments = appointmentsByDate[selectedDate] ?? [];
 
@@ -141,7 +125,7 @@ export default function ScheduleScreen({ appointments = SAMPLE_APPOINTMENTS }) {
         title={getHeaderTitle()}
         onPrev={handlePrev}
         onNext={handleNext}
-        onTitlePress={() => {/* TODO: open date picker */ }}
+        onTitlePress={() => { }}
       />
 
       <div style={styles.content}>
@@ -184,7 +168,7 @@ const styles = {
   screen: {
     display: "flex",
     flexDirection: "column",
-    height: "calc(100vh - 80px)", // 80px = BottomTab height
+    height: "calc(100vh - 80px)",
     background: "#FFFFFF",
     fontFamily: "-apple-system, 'SF Pro Text', 'Helvetica Neue', sans-serif",
     overflow: "hidden",


### PR DESCRIPTION
## What's changed
- Added ScheduleScreen with Month, Week and Day views
- Added EditAppointmentScreen with appointment form
- Added reusable schedule components:
  - ViewSwitcher, CalendarHeader
  - MonthGrid, WeekGrid, DayTimeline
  - AppointmentPill, AppointmentBlock, TimeColumn
  - AppointmentForm, CancelConfirmModal
  - scheduleUtils (shared constants and helpers)
- Updated App.jsx to handle full-height layout and routing

## How to test
1. Run npm run dev
2. Sign in and click Schedule tab
3. Test Month / Week / Day toggle
4. Tap a date in Month view → drills into Day view
5. Tap an appointment block → opens Edit Appointment screen
6. Test Save & Sync and Cancel Appointment buttons

## Notes
- Appointment data is sample data for now, will be replaced with OSCAR API